### PR TITLE
Fix #66 - don't consider a subject with a colon a footer line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,13 @@
-# `git jaspr` (Git Jasper) (Just Another Stacked Pull Request tool)
+# `git jaspr` (Just Another Stacked Pull Request)
 
 This is a reimplementation of [git spr](https://github.com/ejoffe/spr) written in Kotlin.
 
-## Braindump of plan
+## TODO Add documentation 😜
 
-- CLI separated from main logic (naturally)
-- Use Github's graphql API
-  - Create a set of integration tests, but stub the GH API so that it returns actual canned responses, so I can iterate without needing a token or without worrying about the API throttling me
-- Mostly achieve feature parity with git spr, but drop things I don't plan to use
-- Use JGit instead of the command line
-- Tests don't mock git, but actually create a temporary repo to operate on
-- Features to add
-  - Consider minimizing re-verifications
-    - Merging part of the stack currently causes a reverify. It uses the GH API to merge instead of pushing directly, and the GH merge button tends to recreate the commits instead of FF merging them
+## Features to add
   - Branch cleanup
     - An option to remove the branches for merged PRs
     - A command to interactively clean PRs that you opened (to handle orphaned ones)
-  - When determining if a PR is "mergeable", don't use GH's "mergeable" property to determine this. Reason: if the branch protection rules for spr/**/* differ from those of main then GH may think a PR is mergeable when it really isn't. To fix this, we need to determine mergeability by inspecting the branch protection rules
   - Add a tracked Revision to the commit bodies when updating them. Then use this to warn if someone is attempting to jaspr update an older version on top of a newer one. This will typically only happen when collaborating w/others on the same stack
   - Add command to list all PR stacks you have opened
 - Figure out if there's a way to automate publishing like git spr does
-- GraalVM info
-  - I've attempted to implement GraalVM native binaries and have been thwarted due to two issues. The first is an error I ran into that seems to indicate an incompatibility between aarch64 and Java 17. I tried to bump to Java 21, but I ran into an issue with Kotlin 1.9.20 and Java 21 related to annotation processing/kapt that is supposedly fixed in 1.9.21 which isn't out yet. I can wait for that, or I can find another way to handle the test DSL code generation, like splitting the model into a separate module that uses Java 11 or 17 and then consuming it from the jaspr module set to Java 21 and using Graal. Thus avoiding using a combination of Java 21 and Kapt.

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CommitFooters.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CommitFooters.kt
@@ -11,7 +11,9 @@ object CommitFooters {
     }
 
     fun getFooters(fullMessage: String): Map<String, String> {
-        val maybeFooterSection = fullMessage.trim().substringAfterLast("\n\n")
+        val fullMessageTrimmed = fullMessage.trim()
+        val maybeFooterSection = fullMessageTrimmed.substringAfterLast("\n\n")
+        if (maybeFooterSection == fullMessageTrimmed) return emptyMap() // Just a subject
         val maybeFooterLines = maybeFooterSection.lines().map { line -> line.split("\\s*:\\s*".toRegex()) }
         return if (maybeFooterLines.all { list -> list.size == 2 }) {
             maybeFooterLines.associate { (k, v) -> k to v }

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CommitFootersTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CommitFootersTest.kt
@@ -230,6 +230,24 @@ class CommitFootersTest {
     }
 
     @Test
+    fun `addFooters - subject that looks like a footer line`() {
+        val message = """
+            Market Explorer: Remove unused code
+
+        """.trimIndent()
+
+        assertEquals(
+            """
+            Market Explorer: Remove unused code
+
+            key1: value1
+
+            """.trimIndent(),
+            addFooters(message, mapOf("key1" to "value1")),
+        )
+    }
+
+    @Test
     fun `trimFooters - subject only`() {
         assertEquals(
             "This is a subject\n",

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -10,6 +10,9 @@ import sims.michael.gitjaspr.githubtests.TestCaseData
 import sims.michael.gitjaspr.githubtests.generatedtestdsl.testCase
 import kotlin.test.assertEquals
 
+// TODO
+//   Some of these tests fail when ran as one of the functional test implementations due to the expected strings not
+//   being properly parameterized for things like the github URI and the auto-assigned PR numbers. Need to fix this.
 interface GitJasprTest {
 
     val logger: Logger
@@ -1136,10 +1139,14 @@ A
 **Stack**:
 - #6
 - #0 ⬅
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_01..jaspr/main/A)
 - #1
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_01..jaspr/main/B)
 - #5
 - #2
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/C_01..jaspr/main/C)
 - #4
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/E_01..jaspr/main/E)
 
                     """.trimIndent().toPrBodyString(),
                     """
@@ -1148,10 +1155,14 @@ B
 **Stack**:
 - #6
 - #0
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_01..jaspr/main/A)
 - #1 ⬅
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_01..jaspr/main/B)
 - #5
 - #2
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/C_01..jaspr/main/C)
 - #4
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/E_01..jaspr/main/E)
 
                     """.trimIndent().toPrBodyString(),
                     """
@@ -1160,10 +1171,14 @@ C
 **Stack**:
 - #6
 - #0
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_01..jaspr/main/A)
 - #1
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_01..jaspr/main/B)
 - #5
 - #2 ⬅
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/C_01..jaspr/main/C)
 - #4
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/E_01..jaspr/main/E)
 
                     """.trimIndent().toPrBodyString(),
                     """
@@ -1183,10 +1198,14 @@ E
 **Stack**:
 - #6
 - #0
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_01..jaspr/main/A)
 - #1
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_01..jaspr/main/B)
 - #5
 - #2
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/C_01..jaspr/main/C)
 - #4 ⬅
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/E_01..jaspr/main/E)
 
                     """.trimIndent().toPrBodyString(),
                     """
@@ -1195,10 +1214,14 @@ one
 **Stack**:
 - #6
 - #0
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_01..jaspr/main/A)
 - #1
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_01..jaspr/main/B)
 - #5 ⬅
 - #2
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/C_01..jaspr/main/C)
 - #4
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/E_01..jaspr/main/E)
 
                     """.trimIndent().toPrBodyString(),
                     """
@@ -1207,10 +1230,123 @@ two
 **Stack**:
 - #6 ⬅
 - #0
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_01..jaspr/main/A)
 - #1
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_01..jaspr/main/B)
 - #5
 - #2
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/C_01..jaspr/main/C)
 - #4
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/E_01..jaspr/main/E)
+
+                    """.trimIndent().toPrBodyString(),
+                ),
+                gitHub.getPullRequests().map(PullRequest::body),
+            )
+        }
+    }
+
+    @Test
+    fun `pr descriptions force pushed twice`() {
+        withTestSetup(useFakeRemote) {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit { title = "A" }
+                        commit { title = "B" }
+                        commit {
+                            title = "C"
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            push()
+
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit { title = "A" }
+                        commit { title = "B" }
+                        commit {
+                            title = "D"
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            push()
+
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit { title = "A" }
+                        commit { title = "B" }
+                        commit {
+                            title = "E"
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            push()
+
+            assertEquals(
+                listOf(
+                    """
+A
+
+**Stack**:
+- #4
+- #1
+  - [02..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_02..jaspr/main/B), [01..02](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_01..jaspr/main/B_02)
+- #0 ⬅
+  - [02..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_02..jaspr/main/A), [01..02](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_01..jaspr/main/A_02)
+
+                    """.trimIndent().toPrBodyString(),
+                    """
+B
+
+**Stack**:
+- #4
+- #1 ⬅
+  - [02..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_02..jaspr/main/B), [01..02](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_01..jaspr/main/B_02)
+- #0
+  - [02..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_02..jaspr/main/A), [01..02](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_01..jaspr/main/A_02)
+
+                    """.trimIndent().toPrBodyString(),
+                    """
+C
+
+**Stack**:
+- #2 ⬅
+- #1
+- #0
+
+                    """.trimIndent().toPrBodyString(),
+                    """
+D
+
+**Stack**:
+- #3 ⬅
+- #1
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_01..jaspr/main/B)
+- #0
+  - [01..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_01..jaspr/main/A)
+
+                    """.trimIndent().toPrBodyString(),
+                    """
+E
+
+**Stack**:
+- #4 ⬅
+- #1
+  - [02..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_02..jaspr/main/B), [01..02](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/B_01..jaspr/main/B_02)
+- #0
+  - [02..Current](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_02..jaspr/main/A), [01..02](https://example.com/SomeOwner/SomeRepo/compare/jaspr/main/A_01..jaspr/main/A_02)
 
                     """.trimIndent().toPrBodyString(),
                 ),

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -664,7 +664,7 @@ interface GitJasprTest {
     }
 
     @Test
-    fun `commit ID is appended successfully`() {
+    fun `adding commit ID does not indent subject line`() {
         // assert the absence of a bug that used to occur with commits that had message bodies... the subject and footer
         // lines would be indented, which was invalid and would cause the commit(s) to effectively have no ID
         // if this test doesn't throw, then we're good
@@ -696,6 +696,35 @@ interface GitJasprTest {
             )
 
             push()
+        }
+    }
+
+    @Test
+    fun `commit ID is added with a blank line before it`() {
+        withTestSetup(useFakeRemote) {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "Market Explorer: Remove unused code"
+                            id = ""
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            push()
+
+            assertEquals(
+                """
+Market Explorer: Remove unused code
+
+commit-id: 0
+
+                """.trimIndent(),
+                localGit.log("HEAD", maxCount = 1).single().fullMessage,
+            )
         }
     }
 

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -1059,6 +1059,8 @@ interface GitJasprTest {
 1
 
 **Stack**:
+- #2
+- #1
 - #0 ⬅
 
                     """.trimIndent().toPrBodyString(),
@@ -1066,6 +1068,7 @@ interface GitJasprTest {
 2
 
 **Stack**:
+- #2
 - #1 ⬅
 - #0
 
@@ -1131,6 +1134,7 @@ This is a body
 A
 
 **Stack**:
+- #6
 - #0 ⬅
 - #1
 - #5
@@ -1142,6 +1146,8 @@ A
 B
 
 **Stack**:
+- #6
+- #0
 - #1 ⬅
 - #5
 - #2
@@ -1152,6 +1158,10 @@ B
 C
 
 **Stack**:
+- #6
+- #0
+- #1
+- #5
 - #2 ⬅
 - #4
 
@@ -1160,6 +1170,7 @@ C
 D
 
 **Stack**:
+- #4
 - #3 ⬅
 - #2
 - #1
@@ -1170,6 +1181,11 @@ D
 E
 
 **Stack**:
+- #6
+- #0
+- #1
+- #5
+- #2
 - #4 ⬅
 
                     """.trimIndent().toPrBodyString(),
@@ -1177,6 +1193,9 @@ E
 one
 
 **Stack**:
+- #6
+- #0
+- #1
 - #5 ⬅
 - #2
 - #4

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
@@ -398,7 +398,7 @@ class GitHubTestHarness private constructor(
             val configByUserKey = properties.getConfigByUserKeyFromPropertiesFile()
 
             val githubUri = properties["$PROPERTIES_PREFIX.$PROPERTY_GITHUB_URI"]
-            val gitHubInfo = if (githubUri != null) {
+            val gitHubInfo = if (githubUri != null && !useFakeRemote) {
                 requireNotNull(extractGitHubInfoFromUri(githubUri)) { "Unable to extract GitHubInfo from $githubUri" }
             } else {
                 GitHubInfo("example.com", "SomeOwner", "SomeRepo")


### PR DESCRIPTION
Fix #66 - don't consider a subject with a colon a footer line

**Stack**:
- #71
- #70 ⬅
  - [04..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/35528523_04..jaspr/main/35528523), [03..04](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/35528523_03..jaspr/main/35528523_04), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/35528523_02..jaspr/main/35528523_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/35528523_01..jaspr/main/35528523_02)
- #69
  - [04..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/18b5f9a9_04..jaspr/main/18b5f9a9), [03..04](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/18b5f9a9_03..jaspr/main/18b5f9a9_04), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/18b5f9a9_02..jaspr/main/18b5f9a9_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/18b5f9a9_01..jaspr/main/18b5f9a9_02)
- #68
  - [04..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/05031dda_04..jaspr/main/05031dda), [03..04](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/05031dda_03..jaspr/main/05031dda_04), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/05031dda_02..jaspr/main/05031dda_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/05031dda_01..jaspr/main/05031dda_02)
- #67
  - [04..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/2be017a7_04..jaspr/main/2be017a7), [03..04](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/2be017a7_03..jaspr/main/2be017a7_04), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/2be017a7_02..jaspr/main/2be017a7_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/2be017a7_01..jaspr/main/2be017a7_02)

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
