### PR TITLE
GitHubTestHarness does not recreate commits that have not changed

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
@@ -38,6 +38,17 @@ class JGitClient(val workingDirectory: File, val remoteBranchPrefix: String = DE
             .toSortedMap()
     }
 
+    fun getParents(commit: Commit): List<Commit> = useGit { git ->
+        git
+            .log()
+            .add(git.repository.resolve(commit.hash))
+            .setMaxCount(1)
+            .call()
+            .single()
+            .parents
+            .map { it.toCommit(git) }
+    }
+
     fun log(revision: String, maxCount: Int = -1): List<Commit> = useGit { git ->
         git
             .log()


### PR DESCRIPTION
GitHubTestHarness does not recreate commits that have not changed

If a commit already exists, I check it out instead of cherry picking it

**Stack**:
- #77
- #76
- #75
- #74
- #73
- #72 ⬅
- #71

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
