### PR TITLE
Add messaging when merging an empty stack

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -253,6 +253,10 @@ class GitJaspr(
         }
 
         val stack = gitClient.getLocalCommitStack(remoteName, refSpec.localRef, refSpec.remoteRef)
+        if (stack.isEmpty()) {
+            logger.warn("Stack is empty.")
+            return
+        }
 
         val statuses = getRemoteCommitStatuses(stack)
 

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -1379,6 +1379,13 @@ E
 
     //region merge tests
     @Test
+    fun `merge empty stack`() {
+        withTestSetup(useFakeRemote) {
+            merge(RefSpec("main", "main"))
+        }
+    }
+
+    @Test
     fun `merge happy path`() {
         withTestSetup(useFakeRemote) {
             createCommitsFrom(


### PR DESCRIPTION
Add messaging when merging an empty stack

**Stack**:
- #77
- #76 ⬅
- #75
- #74
- #73
- #78

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
