### PR TITLE
PRs are opened in draft mode for commits that begin with /^draft\b/

### DIFF
--- a/git-jaspr/src/graphql/createPullRequest.graphql
+++ b/git-jaspr/src/graphql/createPullRequest.graphql
@@ -9,6 +9,7 @@ mutation createPullRequest($input: CreatePullRequestInput!) {
             headRefName
             reviewDecision
             permalink
+            isDraft
             commits(first:25) {
                 nodes {
                     commit {

--- a/git-jaspr/src/graphql/getPullRequests.graphql
+++ b/git-jaspr/src/graphql/getPullRequests.graphql
@@ -23,6 +23,7 @@ query getPullRequests(
                 mergeable
                 reviewDecision
                 permalink
+                isDraft
                 repository {
                     id
                 }

--- a/git-jaspr/src/graphql/getPullRequestsByHeadRef.graphql
+++ b/git-jaspr/src/graphql/getPullRequestsByHeadRef.graphql
@@ -24,6 +24,7 @@ query getPullRequestsByHeadRef(
                 mergeable
                 reviewDecision
                 permalink
+                isDraft
                 repository {
                     id
                 }

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitHubClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitHubClient.kt
@@ -82,6 +82,7 @@ class GitHubClientImpl(
                         },
                         pr.conclusionStates,
                         pr.permalink,
+                        pr.isDraft,
                     )
                 } else {
                     null
@@ -132,6 +133,7 @@ class GitHubClientImpl(
                     },
                     pr.conclusionStates,
                     pr.permalink,
+                    pr.isDraft,
                 )
             }
             .also { pullRequests -> logger.trace("getPullRequests {}: {}", pullRequests.size, pullRequests) }
@@ -150,6 +152,7 @@ class GitHubClientImpl(
                             repositoryId = repositoryId(),
                             title = pullRequest.title,
                             body = pullRequest.body,
+                            draft = pullRequest.isDraft,
                         ),
                     ),
                 ),
@@ -188,6 +191,7 @@ class GitHubClientImpl(
                 else -> null
             },
             permalink = pr.permalink,
+            isDraft = pr.isDraft,
         )
     }
 

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -8,6 +8,7 @@ import sims.michael.gitjaspr.GitJaspr.StatusBits.Status.*
 import sims.michael.gitjaspr.RemoteRefEncoding.REV_NUM_DELIMITER
 import sims.michael.gitjaspr.RemoteRefEncoding.buildRemoteRef
 import sims.michael.gitjaspr.RemoteRefEncoding.getRemoteRefParts
+import kotlin.text.RegexOption.IGNORE_CASE
 import kotlin.time.Duration.Companion.seconds
 
 class GitJaspr(
@@ -52,6 +53,7 @@ class GitJaspr(
 
         val existingPrsByCommitId = pullRequestsRebased.associateBy(PullRequest::commitId)
 
+        val isDraftRegex = "^draft\\b.*$".toRegex(IGNORE_CASE)
         val prsToMutate = stack
             .windowedPairs()
             .map { (prevCommit, currentCommit) ->
@@ -71,6 +73,7 @@ class GitJaspr(
                     approved = existingPr?.approved,
                     checkConclusionStates = existingPr?.checkConclusionStates.orEmpty(),
                     permalink = existingPr?.permalink,
+                    isDraft = isDraftRegex.matches(currentCommit.shortMessage),
                 )
             }
             .filter { pr -> existingPrsByCommitId[pr.commitId] != pr }

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Model.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Model.kt
@@ -75,6 +75,7 @@ data class PullRequest(
     val approved: Boolean? = null,
     val checkConclusionStates: List<String> = emptyList(),
     val permalink: String? = null,
+    val isDraft: Boolean = false,
     // TODO add state?
     // TODO add draft?
     // TODO add commits

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -1066,6 +1066,32 @@ commit-id: 0
             assertEquals(commits, prs)
         }
     }
+
+    @Test
+    fun `push creates draft PRs based on commit subject`() {
+        withTestSetup(useFakeRemote) {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "DRAFT: this is a test"
+                            id = "a"
+                        }
+                        commit {
+                            title = "b"
+                            localRefs += "development"
+                        }
+                    }
+                },
+            )
+            push()
+
+            assertEquals(
+                listOf(true, false),
+                gitHub.getPullRequests().map(PullRequest::isDraft),
+            )
+        }
+    }
     //endregion
 
     // region pr body tests

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
@@ -17,6 +17,7 @@ import java.io.IOException
 import java.nio.file.Files
 import java.util.Properties
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.text.RegexOption.IGNORE_CASE
 
 class GitHubTestHarness private constructor(
     val scratchDir: File,
@@ -177,6 +178,7 @@ class GitHubTestHarness private constructor(
                 .appendText("This is an uncommitted change.\n")
         }
 
+        val isDraftRegex = "^draft\\b.*$".toRegex(IGNORE_CASE)
         val prs = testCase.pullRequests
         if (prs.isNotEmpty()) {
             val existingPrsByTitle = gitHub.getPullRequestsById().associateBy(PullRequest::title)
@@ -201,6 +203,7 @@ class GitHubTestHarness private constructor(
                     checksPass = commitsByTitle[pr.title]?.willPassVerification,
                     approved = pr.willBeApprovedByUserKey?.isNotBlank(),
                     permalink = "http://example.com",
+                    isDraft = isDraftRegex.matches(pr.title),
                 )
                 val existingPr = existingPrsByTitle[pr.title]
                 val createdOrUpdatedPr = if (existingPr == null) {


### PR DESCRIPTION
PRs are opened in draft mode for commits that begin with /^draft\b/

**Stack**:
- #80 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I7fa19d21_01..jaspr/main/I7fa19d21)

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
