### PR TITLE
FIX: Do not delete the last merged branch if PRs use it as a base

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -1934,12 +1934,12 @@ E
                         commit {
                             title = "b"
                             willPassVerification = true
+                            localRefs += "dev2"
                             remoteRefs += buildRemoteRef("b")
                         }
                         commit {
                             title = "c"
                             willPassVerification = true
-                            localRefs += "dev2"
                             remoteRefs += buildRemoteRef("c")
                         }
                     }
@@ -1972,7 +1972,16 @@ E
 
             waitForChecksToConclude("z", "a", "b", "c")
             merge(RefSpec("dev2", "main"))
-            assertEquals(listOf("main"), localGit.getRemoteBranches().map(RemoteBranch::name))
+            assertEquals(
+                listOf(
+                    buildRemoteRef("b"),
+                    buildRemoteRef("b_01"),
+                    buildRemoteRef("c"),
+                    buildRemoteRef("c_01"),
+                    "main",
+                ),
+                localGit.getRemoteBranches().map(RemoteBranch::name),
+            )
         }
     }
     //endregion


### PR DESCRIPTION
FIX: Do not delete the last merged branch if PRs use it as a base

If a PR's base branch is deleted, it is automatically closed. We don't
want this if it's not merged yet, so handle this case correctly

**Stack**:
- #87
- #86
- #85
- #84 ⬅
- #83

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
