### PR TITLE
Fix logic bug in GitHubStubClient

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
@@ -62,7 +62,7 @@ class GitHubStubClient(private val remoteBranchPrefix: String, private val local
 
     override suspend fun closePullRequest(pullRequest: PullRequest) {
         synchronized(prs) {
-            val i = prs.openPullRequests().indexOfFirst { it == pullRequest }
+            val i = prs.map(PullRequestAndState::pullRequest).indexOfFirst { it == pullRequest }
             require(i > -1) { "PR was not found" }
             prs[i] = prs[i].copy(open = false)
         }
@@ -75,7 +75,7 @@ class GitHubStubClient(private val remoteBranchPrefix: String, private val local
     override suspend fun updatePullRequest(pullRequest: PullRequest) {
         logger.trace("updatePullRequest {}", pullRequest)
         synchronized(prs) {
-            val i = prs.openPullRequests().indexOfFirst { it.id == pullRequest.id }
+            val i = prs.map(PullRequestAndState::pullRequest).indexOfFirst { it.id == pullRequest.id }
             require(i > -1) { "PR with ID ${pullRequest.id} was not found" }
             prs[i] = prs[i].copy(pullRequest = pullRequest)
         }


### PR DESCRIPTION
Fix logic bug in GitHubStubClient

This one was subtle but it was resulting in the wrong PRs being closed
due to applying an index from one collection to another with a different
length

**Stack**:
- #87
- #86
- #85 ⬅
- #84
- #83

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
