### PR TITLE
When merging a PR with children, rebase the first child post-merge

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -1934,12 +1934,12 @@ E
                         commit {
                             title = "b"
                             willPassVerification = true
+                            localRefs += "dev2"
                             remoteRefs += buildRemoteRef("b")
                         }
                         commit {
                             title = "c"
                             willPassVerification = true
-                            localRefs += "dev2"
                             remoteRefs += buildRemoteRef("c")
                         }
                     }
@@ -1972,7 +1972,16 @@ E
 
             waitForChecksToConclude("z", "a", "b", "c")
             merge(RefSpec("dev2", "main"))
-            assertEquals(listOf("main"), localGit.getRemoteBranches().map(RemoteBranch::name))
+            assertEquals(
+                listOf(
+                    buildRemoteRef("b"),
+                    buildRemoteRef("b_01"),
+                    buildRemoteRef("c"),
+                    buildRemoteRef("c_01"),
+                    "main",
+                ),
+                localGit.getRemoteBranches().map(RemoteBranch::name),
+            )
         }
     }
     //endregion

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
@@ -62,7 +62,7 @@ class GitHubStubClient(private val remoteBranchPrefix: String, private val local
 
     override suspend fun closePullRequest(pullRequest: PullRequest) {
         synchronized(prs) {
-            val i = prs.openPullRequests().indexOfFirst { it == pullRequest }
+            val i = prs.map(PullRequestAndState::pullRequest).indexOfFirst { it == pullRequest }
             require(i > -1) { "PR was not found" }
             prs[i] = prs[i].copy(open = false)
         }
@@ -75,7 +75,7 @@ class GitHubStubClient(private val remoteBranchPrefix: String, private val local
     override suspend fun updatePullRequest(pullRequest: PullRequest) {
         logger.trace("updatePullRequest {}", pullRequest)
         synchronized(prs) {
-            val i = prs.openPullRequests().indexOfFirst { it.id == pullRequest.id }
+            val i = prs.map(PullRequestAndState::pullRequest).indexOfFirst { it.id == pullRequest.id }
             require(i > -1) { "PR with ID ${pullRequest.id} was not found" }
             prs[i] = prs[i].copy(pullRequest = pullRequest)
         }

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
@@ -62,8 +62,8 @@ class GitHubStubClient(private val remoteBranchPrefix: String, private val local
 
     override suspend fun closePullRequest(pullRequest: PullRequest) {
         synchronized(prs) {
-            val i = prs.map(PullRequestAndState::pullRequest).indexOfFirst { it == pullRequest }
-            require(i > -1) { "PR was not found" }
+            val i = prs.map(PullRequestAndState::pullRequest).indexOfFirst { it.id == pullRequest.id }
+            require(i > -1) { "PR $pullRequest was not found" }
             prs[i] = prs[i].copy(open = false)
         }
     }


### PR DESCRIPTION
When merging a PR with children, rebase the first child post-merge

**Stack**:
- #87
- #86 ⬅
- #85
- #84
- #83

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
