### PR TITLE
Use FORCE_PUSH_PREFIX constant consistently

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -264,7 +264,7 @@ class GitJaspr(
         }
         if (!dryRun) {
             logger.info("Deleting {} branch(es)", orphanedBranches.size)
-            gitClient.push(orphanedBranches.map { RefSpec("+", it) })
+            gitClient.push(orphanedBranches.map { RefSpec(FORCE_PUSH_PREFIX, it) })
         }
     }
 
@@ -406,7 +406,7 @@ class GitJaspr(
                         TargetRefToCommitId(targetRef, commitId) in deletionCandidates
                     } == true
             }
-            .map { branchName -> RefSpec("+", branchName) }
+            .map { branchName -> RefSpec(FORCE_PUSH_PREFIX, branchName) }
         logger.trace("Deletion list {}", branchesToDelete)
         return branchesToDelete
     }

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
@@ -155,7 +155,7 @@ class GitHubTestHarness private constructor(
                 }
 
                 for (remoteRef in commitData.remoteRefs) {
-                    localGit.push(listOf(RefSpec("+HEAD", remoteRef)))
+                    localGit.push(listOf(RefSpec("${FORCE_PUSH_PREFIX}HEAD", remoteRef)))
                 }
 
                 if (commitData.branches.isNotEmpty()) {
@@ -239,7 +239,7 @@ class GitHubTestHarness private constructor(
                 restoreRegex.matchEntire(name)
             }
             .map {
-                RefSpec("+" + it.groupValues[0], it.groupValues[1])
+                RefSpec(FORCE_PUSH_PREFIX + it.groupValues[0], it.groupValues[1])
             }
 
         // TODO this currently deletes all "jaspr/" branches indiscriminately. Much better would be to capture the ones
@@ -251,7 +251,7 @@ class GitHubTestHarness private constructor(
         val toDelete = localGit.getBranchNames()
             .mapNotNull { name -> deleteRegex.matchEntire(name) }
             .map { result ->
-                RefSpec("+", result.groupValues.last(String::isNotBlank))
+                RefSpec(FORCE_PUSH_PREFIX, result.groupValues.last(String::isNotBlank))
             }
         val refSpecs = (toRestore + toDelete).distinct()
         logger.debug("Pushing {}", refSpecs)


### PR DESCRIPTION
Use FORCE_PUSH_PREFIX constant consistently

**Stack**:
- #104
- #103
- #102
- #101
- #100
- #99
- #98
- #97
- #96
- #95
- #94
- #93
- #92
- #91
- #90
- #89 ⬅
- #88

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
