### PR TITLE
Refactor: extract interface from JGitClient

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/AppWiring.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/AppWiring.kt
@@ -14,13 +14,13 @@ interface AppWiring {
     val gitJaspr: GitJaspr
     val config: Config
     val json: Json
-    val gitClient: JGitClient
+    val gitClient: GitClient
 }
 
 class DefaultAppWiring(
     githubToken: String,
     override val config: Config,
-    override val gitClient: JGitClient,
+    override val gitClient: GitClient,
 ) : AppWiring {
 
     private val gitHubClientWiring = GitHubClientWiring(githubToken, config.gitHubInfo, config.remoteBranchPrefix)

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -252,14 +252,14 @@ abstract class GitJasprCommand(help: String = "", hidden: Boolean = false) :
         DefaultAppWiring(githubToken, config, gitClient)
     }
 
-    private fun determineGithubInfo(jGitClient: JGitClient): GitHubInfo {
+    private fun determineGithubInfo(gitClient: GitClient): GitHubInfo {
         val host = gitHubOptions.githubHost
         val owner = gitHubOptions.repoOwner
         val name = gitHubOptions.repoName
         return if (host != null && owner != null && name != null) {
             GitHubInfo(host, owner, name)
         } else {
-            val remoteUri = requireNotNull(jGitClient.getRemoteUriOrNull(remoteName)) {
+            val remoteUri = requireNotNull(gitClient.getRemoteUriOrNull(remoteName)) {
                 "Couldn't determine URI for remote named $remoteName"
             }
             val fromUri = requireNotNull(extractGitHubInfoFromUri(remoteUri)) {
@@ -404,7 +404,7 @@ object Cli {
 
 const val WORKING_DIR_PROPERTY_NAME = "git-jaspr-working-dir"
 const val CONFIG_FILE_NAME = ".git-jaspr.properties"
-const val DEFAULT_LOCAL_OBJECT = JGitClient.HEAD
+const val DEFAULT_LOCAL_OBJECT = GitClient.HEAD
 const val DEFAULT_TARGET_REF = "main"
 const val DEFAULT_REMOTE_NAME = "origin"
 const val COMMIT_ID_LABEL = "commit-id"

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -13,7 +13,7 @@ import kotlin.time.Duration.Companion.seconds
 
 class GitJaspr(
     private val ghClient: GitHubClient,
-    private val gitClient: JGitClient,
+    private val gitClient: GitClient,
     private val config: Config,
     private val newUuid: () -> String = { generateUuid() },
 ) {

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliTest.kt
@@ -259,7 +259,7 @@ private fun getEffectiveConfigFromCli(
         repoDirConfig,
         listOf("status", "--show-config", remoteName),
         invokeLocation,
-    ),
+    ).also { println(it) },
 )
 
 object ExecuteCli { // Wrapper object so we can have a logger with a sensible name

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalTest.kt
@@ -53,13 +53,13 @@ class GitJasprFunctionalTest : GitJasprTest {
 
             gitJaspr.push()
 
-            val testCommits = localGit.log(JGitClient.HEAD, 3)
+            val testCommits = localGit.log(GitClient.HEAD, 3)
             val testCommitIds = testCommits.mapNotNull(Commit::id).toSet()
             val remotePrs = gitHub.getPullRequests(testCommits)
             val remotePrIds = remotePrs.mapNotNull(PullRequest::commitId).toSet()
             assertEquals(testCommitIds, remotePrIds)
 
-            val headCommit = localGit.log(JGitClient.HEAD, 1).single()
+            val headCommit = localGit.log(GitClient.HEAD, 1).single()
             val headCommitId = checkNotNull(headCommit.id)
             assertEquals("four", remotePrs.single { it.commitId == headCommitId }.title)
         }

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -818,8 +818,8 @@ commit-id: 0
                     assertTrue(
                         localGit
                             .logRange(
-                                "${JGitClient.HEAD}~$numCommits",
-                                JGitClient.HEAD,
+                                "${GitClient.HEAD}~$numCommits",
+                                GitClient.HEAD,
                             )
                             .mapNotNull(Commit::id)
                             .filter(String::isNotBlank)
@@ -1050,7 +1050,7 @@ commit-id: 0
 
             val prs = remotePrs.map { pullRequest -> pullRequest.baseRefName to pullRequest.headRefName }.toSet()
             val commits = localGit
-                .log(JGitClient.HEAD, 6)
+                .log(GitClient.HEAD, 6)
                 .reversed()
                 .windowedPairs()
                 .map { (prevCommit, currentCommit) ->

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
@@ -6,7 +6,7 @@ import sims.michael.gitjaspr.Commit
 import sims.michael.gitjaspr.PullRequest
 import sims.michael.gitjaspr.RemoteRefEncoding.getCommitIdFromRemoteRef
 
-class GitHubStubClient(private val remoteBranchPrefix: String, private val localGit: JGitClient) : GitHubClient {
+class GitHubStubClient(private val remoteBranchPrefix: String, private val localGit: GitClient) : GitHubClient {
 
     private val logger = LoggerFactory.getLogger(GitHubStubClient::class.java)
 

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
@@ -30,8 +30,8 @@ class GitHubTestHarness private constructor(
     private val useFakeRemote: Boolean = true,
 ) {
 
-    val localGit: JGitClient = JGitClient(localRepo)
-    private val remoteGit: JGitClient = JGitClient(remoteRepo)
+    val localGit: GitClient = JGitClient(localRepo)
+    private val remoteGit: GitClient = JGitClient(remoteRepo)
 
     private val ghClientsByUserKey: Map<String, GitHubClient> by lazy {
         if (!useFakeRemote) {
@@ -245,7 +245,7 @@ class GitHubTestHarness private constructor(
         // TODO this currently deletes all "jaspr/" branches indiscriminately. Much better would be to capture the ones
         //  we created via our JGitClient and delete only those
         val deleteRegex =
-            "($DELETE_PREFIX(.*)|${JGitClient.R_REMOTES}$DEFAULT_REMOTE_NAME/($remoteBranchPrefix.*))"
+            "($DELETE_PREFIX(.*)|${GitClient.R_REMOTES}$DEFAULT_REMOTE_NAME/($remoteBranchPrefix.*))"
                 .toRegex()
 
         val toDelete = localGit.getBranchNames()
@@ -288,7 +288,7 @@ class GitHubTestHarness private constructor(
         }
     }
 
-    private fun JGitClient.createInitialCommit() = apply {
+    private fun GitClient.createInitialCommit() = apply {
         val repoDir = workingDirectory
         val readme = "README.txt"
         val readmeFile = repoDir.resolve(readme)


### PR DESCRIPTION
Refactor: extract interface from JGitClient

**Stack**:
- #104
- #103
- #102
- #101
- #100
- #99
- #98
- #97
- #96
- #95
- #94
- #93 ⬅
- #92
- #91
- #90
- #89
- #88

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
