### PR TITLE
Add test for status on a non-main branch

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalExternalProcessTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalExternalProcessTest.kt
@@ -46,7 +46,7 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
         ).lines().drop(1).joinToString("\n") // TODO Hacky, drop the first line which is debug output.
     }
 
-    override suspend fun GitHubTestHarness.getAndPrintStatusString(): String {
+    override suspend fun GitHubTestHarness.getAndPrintStatusString(refSpec: RefSpec): String {
         return executeCli(
             scratchDir = scratchDir,
             remoteUri = remoteUri,
@@ -54,7 +54,7 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
             extraCliArgs = emptyList(),
             homeDirConfig = buildHomeDirConfig(),
             repoDirConfig = emptyMap(),
-            strings = listOf("status"),
+            strings = listOf("status", refSpec.toString()),
             invokeLocation = localRepo,
             javaOptions = javaOptions,
 


### PR DESCRIPTION
Add test for status on a non-main branch

**Stack**:
- #104
- #103
- #102
- #101
- #100
- #99
- #98
- #97
- #96
- #95 ⬅
- #94
- #93
- #92
- #91
- #90
- #89
- #88

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
