### PR TITLE
getRemoteRefParts no longer returns separator

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -255,9 +255,7 @@ class GitJaspr(
                 val remoteRefParts = getRemoteRefParts(it, config.remoteBranchPrefix)
                 if (remoteRefParts != null) {
                     val (targetRef, commitId, _) = remoteRefParts
-                    // TODO why is it returning with the separator?
-                    val targetRefWithoutSeparator = targetRef.trim('/')
-                    buildRemoteRef(commitId, targetRefWithoutSeparator) !in pullRequests
+                    buildRemoteRef(commitId, targetRef) !in pullRequests
                 } else {
                     false
                 }

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/RemoteRefEncoding.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/RemoteRefEncoding.kt
@@ -12,7 +12,7 @@ object RemoteRefEncoding {
     ): String = listOf(prefix, targetRef, commitId).joinToString("/")
 
     fun getRemoteRefParts(remoteRef: String, remoteBranchPrefix: String): RemoteRefParts? =
-        "^$remoteBranchPrefix/(.*/)(.*?)(?:$REV_NUM_DELIMITER(\\d+))?$"
+        "^$remoteBranchPrefix/(.*)/(.*?)(?:$REV_NUM_DELIMITER(\\d+))?$"
             .toRegex()
             .matchEntire(remoteRef)
             ?.let { result ->

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/RemoteRefEncodingTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/RemoteRefEncodingTest.kt
@@ -1,0 +1,24 @@
+package sims.michael.gitjaspr
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import sims.michael.gitjaspr.RemoteRefEncoding.RemoteRefParts
+import sims.michael.gitjaspr.RemoteRefEncoding.getRemoteRefParts
+
+class RemoteRefEncodingTest {
+    @Test
+    fun `getRemoteRefParts - no revision number`() {
+        assertEquals(
+            RemoteRefParts("main", "12345", null),
+            getRemoteRefParts("jaspr/main/12345", "jaspr"),
+        )
+    }
+
+    @Test
+    fun `getRemoteRefParts - with revision number`() {
+        assertEquals(
+            RemoteRefParts("main", "12345", 1),
+            getRemoteRefParts("jaspr/main/12345_01", "jaspr"),
+        )
+    }
+}


### PR DESCRIPTION
getRemoteRefParts no longer returns separator

**Stack**:
- #104
- #103
- #102
- #101
- #100
- #99
- #98
- #97 ⬅
- #96
- #95
- #94
- #93
- #92
- #91
- #90
- #89
- #88

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
