### PR TITLE
Move test to superclass

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalTest.kt
@@ -4,12 +4,9 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
-import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestInfo
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import sims.michael.gitjaspr.githubtests.GitHubTestHarness
-import sims.michael.gitjaspr.githubtests.generatedtestdsl.testCase
 import sims.michael.gitjaspr.testing.FunctionalTest
 import kotlin.test.assertEquals
 
@@ -17,53 +14,6 @@ import kotlin.test.assertEquals
 class GitJasprFunctionalTest : GitJasprTest {
     override val logger: Logger = LoggerFactory.getLogger(GitJasprDefaultTest::class.java)
     override val useFakeRemote: Boolean = false
-
-    // TODO this test should be in the super class but it fails when using GitHubStubClient
-    //  look into this
-    @Test
-    fun `amend HEAD commit and re-push`(testInfo: TestInfo) {
-        GitHubTestHarness.withTestSetup(useFakeRemote) {
-            createCommitsFrom(
-                testCase {
-                    repository {
-                        commit { title = "one" }
-                        commit { title = "two" }
-                        commit {
-                            title = "three"
-                            localRefs += "development"
-                        }
-                    }
-                },
-            )
-
-            gitJaspr.push()
-
-            createCommitsFrom(
-                testCase {
-                    repository {
-                        commit { title = "one" }
-                        commit { title = "two" }
-                        commit {
-                            title = "four"
-                            localRefs += "development"
-                        }
-                    }
-                },
-            )
-
-            gitJaspr.push()
-
-            val testCommits = localGit.log(GitClient.HEAD, 3)
-            val testCommitIds = testCommits.mapNotNull(Commit::id).toSet()
-            val remotePrs = gitHub.getPullRequests(testCommits)
-            val remotePrIds = remotePrs.mapNotNull(PullRequest::commitId).toSet()
-            assertEquals(testCommitIds, remotePrIds)
-
-            val headCommit = localGit.log(GitClient.HEAD, 1).single()
-            val headCommitId = checkNotNull(headCommit.id)
-            assertEquals("four", remotePrs.single { it.commitId == headCommitId }.title)
-        }
-    }
 
     override suspend fun GitHubTestHarness.waitForChecksToConclude(
         vararg commitFilter: String,


### PR DESCRIPTION
Move test to superclass

One of the previous bug fixes must have addressed this

**Stack**:
- #104
- #103
- #102
- #101
- #100
- #99
- #98 ⬅
- #97
- #96
- #95
- #94
- #93
- #92
- #91
- #90
- #89
- #88

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
