### PR TITLE
Convert TODOs into regular comments

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Model.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Model.kt
@@ -36,7 +36,8 @@ data class Commit(
     val fullMessage: String,
     val id: String?,
     val committer: Ident = Ident("John F. Zoidberg", "john.f.zoidberg@planetexpress.example.com"),
-    val commitDate: ZonedDateTime = ZonedDateTime.now(), // TODO Format with date.format(DateTimeFormatter.ofPattern("E MMM d, YYYY, h:mm:ss a z"))
+    // Format with date.format(DateTimeFormatter.ofPattern("E MMM d, YYYY, h:mm:ss a z"))
+    val commitDate: ZonedDateTime = ZonedDateTime.now(),
     val authorDate: ZonedDateTime = ZonedDateTime.now(),
 ) {
     override fun toString() = "Commit(id=$id, h=$hash, msg=$shortMessage, committer=$committer)"

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalExternalProcessTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalExternalProcessTest.kt
@@ -43,7 +43,7 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
             strings = listOf("push"),
             invokeLocation = localRepo,
             javaOptions = javaOptions,
-        ).lines().drop(1).joinToString("\n") // TODO Hacky, drop the first line which is debug output.
+        ).lines().drop(1).joinToString("\n") // Hacky, drop the first line which is debug output.
     }
 
     override suspend fun GitHubTestHarness.getAndPrintStatusString(refSpec: RefSpec): String {
@@ -58,7 +58,7 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
             invokeLocation = localRepo,
             javaOptions = javaOptions,
 
-        ).lines().drop(1).joinToString("\n") // TODO Hacky, drop the first line which is debug output.
+        ).lines().drop(1).joinToString("\n") // Hacky, drop the first line which is debug output.
     }
 
     override suspend fun GitHubTestHarness.merge(refSpec: RefSpec) {

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
@@ -86,8 +86,8 @@ class GitHubTestHarness private constructor(
 
         val initialCommit = localGit.log(DEFAULT_TARGET_REF).last()
 
-        // TODO This saves the state of `main` so it will be restored even if moved by an "external" process
-        //   This is for functional tests so I can roll them back when done. I need a better comment here.
+        // This saves the state of `main` so it will be restored even if moved by an "external" process
+        // This is for functional tests so I can roll them back when done.
         val initialRestoreMarker = "$RESTORE_PREFIX$DEFAULT_TARGET_REF"
         if (!localGit.getBranchNames().contains(initialRestoreMarker)) {
             localGit.branch(initialRestoreMarker, startPoint = initialCommit.hash)
@@ -108,8 +108,9 @@ class GitHubTestHarness private constructor(
                 val existingHash = commitHashesByTitle[commitData.title]
                 val commit = if (existingHash != null) {
                     // A commit with this title already exists... if it's a direct child of this commit, simply check
-                    // it out. Otherwise cherry-pick it
-                    // TODO but what if this version of the commit differs? shouldn't we amend it?
+                    // it out. Otherwise cherry-pick it.
+                    // Note that we don't support amending commits, so it's not really possible to _change_ a commit
+                    // using this test harness.
                     val headHash = localGit.log("HEAD", 1).single().hash
                     val parentHashes = localGit.getParents(localGit.log(existingHash, 1).single()).map(Commit::hash)
                     if (headHash in parentHashes) {
@@ -196,10 +197,10 @@ class GitHubTestHarness private constructor(
                     baseRefName = pr.baseRef,
                     title = pr.title,
                     body = pr.body,
-                    // TODO
-                    //   This logic is incomplete. In this context, we could have PRs with multiple commits. If we want
-                    //   to support this so we can test how JASPR reacts, this logic needs to be updated to set
-                    //   checksPass only if _all_ commits in the PR will pass
+                    // This logic is incomplete. In this context, we could have PRs with multiple commits. If we want
+                    // to support this so we can test how JASPR reacts, this logic needs to be updated to set
+                    // checksPass only if _all_ commits in the PR will pass. It's unlikely that I'll make this change
+                    // but I'll leave this comment here
                     checksPass = commitsByTitle[pr.title]?.willPassVerification,
                     approved = pr.willBeApprovedByUserKey?.isNotBlank(),
                     permalink = "http://example.com",
@@ -242,8 +243,8 @@ class GitHubTestHarness private constructor(
                 RefSpec(FORCE_PUSH_PREFIX + it.groupValues[0], it.groupValues[1])
             }
 
-        // TODO this currently deletes all "jaspr/" branches indiscriminately. Much better would be to capture the ones
-        //  we created via our JGitClient and delete only those
+        // This currently deletes all "jaspr/" branches indiscriminately. Much better would be to capture the ones
+        // we created via our JGitClient and delete only those
         val deleteRegex =
             "($DELETE_PREFIX(.*)|${GitClient.R_REMOTES}$DEFAULT_REMOTE_NAME/($remoteBranchPrefix.*))"
                 .toRegex()


### PR DESCRIPTION
Convert TODOs into regular comments

**Stack**:
- #104
- #103
- #102
- #101
- #100 ⬅
- #99
- #98
- #97
- #96
- #95
- #94
- #93
- #92
- #91
- #90
- #89
- #88

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
