### PR TITLE
GitHubTestHarness pulls commit ID from pr head ref

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
@@ -12,6 +12,7 @@ import sims.michael.gitjaspr.Commit
 import sims.michael.gitjaspr.Ident
 import sims.michael.gitjaspr.PullRequest
 import sims.michael.gitjaspr.RemoteRefEncoding.DEFAULT_REMOTE_BRANCH_PREFIX
+import sims.michael.gitjaspr.RemoteRefEncoding.getRemoteRefParts
 import java.io.File
 import java.io.IOException
 import java.nio.file.Files
@@ -188,10 +189,7 @@ class GitHubTestHarness private constructor(
                 val gitHubClient = (ghClientsByUserKey[pr.userKey] ?: gitHub)
                 val newPullRequest = PullRequest(
                     id = null,
-                    // TODO
-                    //  This logic is suspect. We should be pulling the commit ID from the headRef or from the
-                    //  footer lines.
-                    commitId = commitsByTitle[pr.title]?.id,
+                    commitId = getRemoteRefParts(pr.headRef, remoteBranchPrefix)?.commitId,
                     number = null,
                     headRefName = pr.headRef,
                     baseRefName = pr.baseRef,


### PR DESCRIPTION
GitHubTestHarness pulls commit ID from pr head ref

**Stack**:
- #104
- #103
- #102
- #101 ⬅
- #100
- #99
- #98
- #97
- #96
- #95
- #94
- #93
- #92
- #91
- #90
- #89
- #88

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
