### PR TITLE
BUG FIX: merge honors the "stack check"

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -172,7 +172,14 @@ class GitJaspr(
 
         val statuses = getRemoteCommitStatuses(stack)
 
-        val indexLastMergeable = statuses.indexOfLast { it.approved == true && it.checksPass == true }
+        // Do a "stack check"... find the first commit that either isn't approved or fails checks, and the one before
+        // it is the last mergeable commit.
+        val firstIndexNotMergeable = statuses.indexOfFirst { it.approved != true || it.checksPass != true }
+        val indexLastMergeable = if (firstIndexNotMergeable == -1) {
+            statuses.lastIndex
+        } else {
+            firstIndexNotMergeable - 1
+        }
         if (indexLastMergeable == -1) {
             logger.warn("No commits in your local stack are mergeable.")
             return

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -1684,46 +1684,68 @@ E
                 testCase {
                     repository {
                         commit {
-                            title = "one"
+                            title = "a"
                             willPassVerification = true
-                            remoteRefs += buildRemoteRef("one")
+                            remoteRefs += buildRemoteRef("a")
                         }
                         commit {
-                            title = "two"
+                            title = "b"
                             willPassVerification = true
-                            remoteRefs += buildRemoteRef("two")
+                            remoteRefs += buildRemoteRef("b")
                         }
                         commit {
-                            title = "three"
+                            title = "c"
                             willPassVerification = true
-                            remoteRefs += buildRemoteRef("three")
+                            remoteRefs += buildRemoteRef("c")
+                        }
+                        commit {
+                            title = "d"
+                            willPassVerification = true
+                            remoteRefs += buildRemoteRef("d")
+                        }
+                        commit {
+                            title = "e"
+                            willPassVerification = true
+                            remoteRefs += buildRemoteRef("e")
                             localRefs += "development"
                         }
                     }
                     pullRequest {
-                        headRef = buildRemoteRef("one")
+                        headRef = buildRemoteRef("a")
                         baseRef = "main"
-                        title = "one"
+                        title = "a"
                         willBeApprovedByUserKey = "michael"
                     }
                     pullRequest {
-                        headRef = buildRemoteRef("two")
-                        baseRef = buildRemoteRef("one")
-                        title = "two"
+                        headRef = buildRemoteRef("b")
+                        baseRef = buildRemoteRef("a")
+                        title = "b"
                         willBeApprovedByUserKey = "michael"
                     }
                     pullRequest {
-                        headRef = buildRemoteRef("three")
-                        baseRef = buildRemoteRef("two")
-                        title = "three"
+                        headRef = buildRemoteRef("c")
+                        baseRef = buildRemoteRef("b")
+                        title = "c"
+                    }
+                    pullRequest {
+                        headRef = buildRemoteRef("d")
+                        baseRef = buildRemoteRef("c")
+                        title = "d"
+                    }
+                    pullRequest {
+                        headRef = buildRemoteRef("e")
+                        baseRef = buildRemoteRef("d")
+                        title = "e"
+                        willBeApprovedByUserKey = "michael"
                     }
                 },
             )
 
-            waitForChecksToConclude("one", "two", "three")
+            waitForChecksToConclude("a", "b", "c", "d", "e")
             merge(RefSpec("development", "main"))
             assertEquals(
-                listOf("three"), // All mergeable commits were merged, leaving "three" as the only one not merged
+                // All mergeable commits were merged, leaving c, d, and e as the only one not merged
+                listOf("c", "d", "e"),
                 localGit
                     .getLocalCommitStack(DEFAULT_REMOTE_NAME, "development", DEFAULT_TARGET_REF)
                     .map(Commit::shortMessage),


### PR DESCRIPTION
BUG FIX: merge honors the "stack check"

This fixes a huge bug where merge would merge all commits that were
verified but not necessarily approved. Now it properly does a "stack
check" and merges the first contiguous group of commits that are all
verified and approved.

**Stack**:
- #105 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
