### PR TITLE
Commit model updates

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Model.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Model.kt
@@ -35,13 +35,11 @@ data class Commit(
     val shortMessage: String,
     val fullMessage: String,
     val id: String?,
-    val committer: Ident = Ident("John F. Zoidberg", "john.f.zoidberg@planetexpress.example.com"),
+    val committer: Ident,
     // Format with date.format(DateTimeFormatter.ofPattern("E MMM d, YYYY, h:mm:ss a z"))
-    val commitDate: ZonedDateTime = ZonedDateTime.now(),
-    val authorDate: ZonedDateTime = ZonedDateTime.now(),
-) {
-    override fun toString() = "Commit(id=$id, h=$hash, msg=$shortMessage, committer=$committer)"
-}
+    val commitDate: ZonedDateTime,
+    val authorDate: ZonedDateTime,
+)
 
 data class Ident(val name: String, val email: String) {
     override fun toString() = "$name <$email>"


### PR DESCRIPTION
Commit model updates

- Use default toString() again (better in unit tests if I can see why
  two instances are different)
- Drop defaults that weren't being used

**Stack**:
- #120
- #114
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I062f53b3_01..jaspr/main/I062f53b3)
- #112
- #111
- #110
- #109 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
