### PR TITLE
Canonicalize dates coming from JGit

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -8,6 +8,7 @@ import sims.michael.gitjaspr.GitJaspr.StatusBits.Status.*
 import sims.michael.gitjaspr.RemoteRefEncoding.REV_NUM_DELIMITER
 import sims.michael.gitjaspr.RemoteRefEncoding.buildRemoteRef
 import sims.michael.gitjaspr.RemoteRefEncoding.getRemoteRefParts
+import java.time.ZonedDateTime
 import kotlin.text.RegexOption.IGNORE_CASE
 import kotlin.time.Duration.Companion.seconds
 
@@ -568,3 +569,6 @@ fun <T : Any> Iterable<T>.windowedPairs(): List<Pair<T?, T>> {
         addAll(iter.windowed(2).map { (prev, current) -> prev to current })
     }
 }
+
+/** Convert [ZonedDateTime] to the simplest representation as an offset from UTC. */
+fun ZonedDateTime.canonicalize(): ZonedDateTime = toOffsetDateTime().toZonedDateTime()

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
@@ -19,7 +19,7 @@ import org.slf4j.LoggerFactory
 import java.io.File
 import java.time.Instant
 import java.time.ZoneId
-import java.time.ZonedDateTime
+import java.time.ZonedDateTime.ofInstant
 
 class JGitClient(
     override val workingDirectory: File,
@@ -292,13 +292,14 @@ class JGitClient(
 private fun RevCommit.toCommit(git: Git): Commit {
     val r = git.repository
     val objectReader = r.newObjectReader()
+    fun PersonIdent.whenAsZonedDateTime() = ofInstant(whenAsInstant, ZoneId.systemDefault()).canonicalize()
     return Commit(
         objectReader.abbreviate(id).name(),
         shortMessage,
         fullMessage,
         CommitParsers.getFooters(fullMessage)[COMMIT_ID_LABEL],
         Ident(committerIdent.name, committerIdent.emailAddress),
-        ZonedDateTime.ofInstant(committerIdent.`when`.toInstant(), ZoneId.systemDefault()),
-        ZonedDateTime.ofInstant(authorIdent.`when`.toInstant(), ZoneId.systemDefault()),
+        committerIdent.whenAsZonedDateTime(),
+        authorIdent.whenAsZonedDateTime(),
     )
 }


### PR DESCRIPTION
Canonicalize dates coming from JGit

This is in preparation for a new CLI-backed implementation of GitClient.
I want to make sure both are representing dates the same hence this
canonicalize function. I'm admittedly cargo-culting this a bit as my
knowledge of the java time API is wanting and this isn't a high
priority part of the app for me

**Stack**:
- #120
- #114
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I062f53b3_01..jaspr/main/I062f53b3)
- #112 ⬅
- #111
- #110
- #109

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
