### PR TITLE
Remove refExists from GitClient interface

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
@@ -52,10 +52,6 @@ class CliGitClient(
         TODO("Not yet implemented")
     }
 
-    override fun refExists(ref: String): Boolean {
-        TODO("Not yet implemented")
-    }
-
     override fun getBranchNames(): List<String> {
         TODO("Not yet implemented")
     }

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
@@ -17,7 +17,6 @@ interface GitClient {
     fun logRange(since: String, until: String): List<Commit>
     fun isWorkingDirectoryClean(): Boolean
     fun getLocalCommitStack(remoteName: String, localObjectName: String, targetRefName: String): List<Commit>
-    fun refExists(ref: String): Boolean
     fun getBranchNames(): List<String>
     fun getRemoteBranches(): List<RemoteBranch>
     fun getRemoteBranchesById(): Map<String, RemoteBranch>

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
@@ -126,7 +126,7 @@ class JGitClient(
         }
     }
 
-    override fun refExists(ref: String): Boolean {
+    private fun refExists(ref: String): Boolean {
         logger.trace("refExists {}", ref)
         return useGit { git -> git.repository.resolve(ref) != null }
     }


### PR DESCRIPTION
Remove refExists from GitClient interface

JGitClient uses this internally only

**Stack**:
- #119
- #118
- #117 ⬅
- #116
- #115
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Idf5c8100_01..jaspr/main/Idf5c8100)
- #114
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I062f53b3_01..jaspr/main/I062f53b3)
- #112
- #111
- #110
- #109

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
