### PR TITLE
Implement CliGitClient.getLocalCommitStack

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
@@ -48,9 +48,8 @@ class CliGitClient(
         .lines
         .isEmpty()
 
-    override fun getLocalCommitStack(remoteName: String, localObjectName: String, targetRefName: String): List<Commit> {
-        TODO("Not yet implemented")
-    }
+    override fun getLocalCommitStack(remoteName: String, localObjectName: String, targetRefName: String): List<Commit> =
+        logRange("$remoteName/$targetRefName", localObjectName)
 
     override fun getBranchNames(): List<String> {
         TODO("Not yet implemented")

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliGitClientTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliGitClientTest.kt
@@ -209,4 +209,39 @@ class CliGitClientTest {
             assertFalse(git.isWorkingDirectoryClean())
         }
     }
+
+    @Test
+    fun `compare getLocalCommitStack`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "main"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            remoteRefs += "main"
+                        }
+                    }
+                },
+            )
+            val git = CliGitClient(localGit.workingDirectory)
+            assertEquals(
+                localGit.getLocalCommitStack(DEFAULT_REMOTE_NAME, DEFAULT_TARGET_REF, DEFAULT_TARGET_REF),
+                git.getLocalCommitStack(DEFAULT_REMOTE_NAME, DEFAULT_TARGET_REF, DEFAULT_TARGET_REF),
+            )
+        }
+    }
 }


### PR DESCRIPTION
Implement CliGitClient.getLocalCommitStack

**Stack**:
- #119
- #118 ⬅
- #117
- #116
- #115
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Idf5c8100_01..jaspr/main/Idf5c8100)
- #114
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I062f53b3_01..jaspr/main/I062f53b3)
- #112
- #111
- #110
- #109

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
