### PR TITLE
Implement CliGitClient.getParents

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
@@ -34,7 +34,17 @@ class CliGitClient(
     override fun logRange(since: String, until: String): List<Commit> = gitLog("$since..$until").reversed()
 
     override fun getParents(commit: Commit): List<Commit> {
-        TODO("Not yet implemented")
+        return ProcessExecutor()
+            .directory(workingDirectory)
+            .command(listOf("git", "log", commit.hash, "--pretty=%P", "-1"))
+            .destroyOnExit()
+            .readOutput(true)
+            .execute()
+            .also(ProcessResult::requireZeroExitValue)
+            .output
+            .string
+            .split(" ")
+            .flatMap { parent -> log(parent.trim(), 1) }
     }
 
     override fun isWorkingDirectoryClean(): Boolean = ProcessExecutor()

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliGitClientTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliGitClientTest.kt
@@ -244,4 +244,40 @@ class CliGitClientTest {
             )
         }
     }
+
+    @Test
+    fun `compare getParents`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "main"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            remoteRefs += "main"
+                        }
+                    }
+                },
+            )
+            val main = localGit.log(DEFAULT_TARGET_REF, 1).single()
+            val git = CliGitClient(localGit.workingDirectory)
+            assertEquals(
+                localGit.getParents(main),
+                git.getParents(main),
+            )
+        }
+    }
 }


### PR DESCRIPTION
Implement CliGitClient.getParents

**Stack**:
- #119 ⬅
- #118
- #117
- #116
- #115
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Idf5c8100_01..jaspr/main/Idf5c8100)
- #114
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I062f53b3_01..jaspr/main/I062f53b3)
- #112
- #111
- #110
- #109

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
