### PR TITLE
Update README.md with missing GH token permission

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ version maybe?) and install it into your `PATH` somewhere (`~/.local/bin`?) and 
 github-token=<GH PAT>
 ```
 
-Where `<GH PAT>` is a GitHub Personal Access Token (classic) with the permissions `read:org`, `read:user`, and 
+Where `<GH PAT>` is a GitHub Personal Access Token (classic) with the permissions `read:org`, `read:user`, `repo`, and 
 `user:email`.
 
 ## Using

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -188,7 +188,7 @@ abstract class GitJasprCommand(help: String = "", hidden: Boolean = false) :
 
     private val githubToken by option(envvar = GITHUB_TOKEN_ENV_VAR).required().help {
         """
-        A GitHub PAT (personal access token) with read:org, read:user, and user:email permissions. Can be provided 
+        A GitHub PAT (personal access token) with read:org, read:user, repo, and user:email permissions. Can be provided 
         via the per-user config file, a per-working copy config file, or the environment variable 
         $GITHUB_TOKEN_ENV_VAR.
         """.trimIndent()


### PR DESCRIPTION
Update README.md with missing GH token permission

**Stack**:
- #133
- #132
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I63183646_01..jaspr/main/I63183646)
- #126
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I5f8995bd_02..jaspr/main/I5f8995bd), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I5f8995bd_01..jaspr/main/I5f8995bd_02)
- #125
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_01..jaspr/main/I2d8e130b)
- #120
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_02..jaspr/main/I31acaa43), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_01..jaspr/main/I31acaa43_02)
- #124 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
