### PR TITLE
Push draft PRs for commit subjects that start with "wip" too

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -395,6 +395,7 @@ object Cli {
         is handled via an abstract base class.
          */
         NoOpCliktCommand(name = "git jaspr")
+            .versionOption("v4-beta")
             .subcommands(
                 listOf(
                     Status(),

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -237,8 +237,16 @@ abstract class GitJasprCommand(help: String = "", hidden: Boolean = false) :
         }
         .default(DEFAULT_REMOTE_NAME)
 
+    private val useCliGitClient by option().flag("--no-use-cli-git-client", default = true)
+        .help { "Use the CLI client instead of the JGit client. This option is slightly slower but has better " +
+            "compatibility with various SSH configurations such as OS X + ssh-agent." }
+
     val appWiring by lazy {
-        val gitClient = JGitClient(workingDirectory, remoteBranchPrefix)
+        val gitClient = if (useCliGitClient) {
+            CliGitClient(workingDirectory, remoteBranchPrefix)
+        } else {
+            JGitClient(workingDirectory, remoteBranchPrefix)
+        }
         val githubInfo = determineGithubInfo(gitClient)
         val config = Config(
             workingDirectory,

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
@@ -1,0 +1,311 @@
+package sims.michael.gitjaspr
+
+import org.slf4j.LoggerFactory
+import org.zeroturnaround.exec.ProcessExecutor
+import org.zeroturnaround.exec.ProcessResult
+import java.io.File
+import java.nio.file.Files
+
+class CliGitClient(
+    override val workingDirectory: File,
+    override val remoteBranchPrefix: String = RemoteRefEncoding.DEFAULT_REMOTE_BRANCH_PREFIX,
+) : GitClient {
+
+    private val logger = LoggerFactory.getLogger(CliGitClient::class.java)
+
+    override fun init(): GitClient {
+        logger.trace("init")
+        require(workingDirectory.exists() || workingDirectory.mkdir()) {
+            "Working directory does not exist and could not be created: $workingDirectory"
+        }
+        return apply { executeCommand(listOf("git", "init", "-b", "main")) }
+    }
+
+    override fun checkout(refName: String): GitClient = apply {
+        logger.trace("checkout {}", refName)
+        executeCommand(listOf("git", "checkout", refName))
+    }
+
+    override fun clone(uri: String, bare: Boolean): GitClient {
+        logger.trace("clone {} {}", uri, bare)
+        // The CLI doesn't support file:// URIs, so we need to strip the prefix
+        val sanitizedUri = uri.removePrefix("file:")
+        require(workingDirectory.exists() || workingDirectory.mkdir()) {
+            "Working directory does not exist and could not be created: $workingDirectory"
+        }
+        val bareOption = if (bare) listOf("--bare") else emptyList()
+        val command = listOf("git", "clone") + bareOption + listOf(sanitizedUri, workingDirectory.absolutePath)
+        return apply {
+            executeCommand(command)
+            // Remove refs/remotes/origin/HEAD to match JGitClient's behavior
+            executeCommand(listOf("git", "remote", "set-head", DEFAULT_REMOTE_NAME, "-d"))
+        }
+    }
+
+    override fun fetch(remoteName: String) {
+        logger.trace("fetch {}", remoteName)
+        executeCommand(listOf("git", "fetch", remoteName))
+    }
+
+    override fun log(): List<Commit> {
+        logger.trace("log")
+        return gitLog().reversed()
+    }
+
+    override fun log(revision: String, maxCount: Int): List<Commit> {
+        return if (maxCount == -1) gitLog(revision) else gitLog(revision, "-$maxCount")
+    }
+
+    override fun logAll(): List<Commit> {
+        logger.trace("logAll")
+        return gitLog("--all").reversed()
+    }
+
+    override fun logRange(since: String, until: String): List<Commit> {
+        logger.trace("logRange {}..{}", since, until)
+        return gitLog("$since..$until").reversed()
+    }
+
+    override fun getParents(commit: Commit): List<Commit> {
+        return executeCommand(listOf("git", "log", commit.hash, "--pretty=%P", "-1"))
+            .output
+            .string
+            .split(" ")
+            .flatMap { parent -> log(parent.trim(), 1) }
+            .also {
+                logger.trace("getParents {} {}", commit, it)
+            }
+    }
+
+    override fun isWorkingDirectoryClean(): Boolean {
+        logger.trace("isWorkingDirectoryClean")
+        return executeCommand(listOf("git", "status", "-s"))
+            .output
+            .lines
+            .isEmpty()
+    }
+
+    override fun getLocalCommitStack(remoteName: String, localObjectName: String, targetRefName: String): List<Commit> {
+        logger.trace("getLocalCommitStack {} {} {}", remoteName, localObjectName, targetRefName)
+        return logRange("$remoteName/$targetRefName", localObjectName)
+    }
+
+    override fun getBranchNames(): List<String> {
+        logger.trace("getBranchNames")
+        return executeCommand(listOf("git", "branch", "-a", "-l", "--format=%(refname:short)"))
+            .output
+            .lines
+            .map { line -> if (line.contains("HEAD detached")) "HEAD" else line }
+    }
+
+    override fun getRemoteBranches(): List<RemoteBranch> {
+        val command = listOf(
+            "git",
+            "branch",
+            "-r",
+            "-l",
+            "--format=%(refname:lstrip=3)${GIT_FORMAT_SEPARATOR}%(objectname:short)",
+        )
+        return executeCommand(command)
+            .output
+            .lines
+            .map { line ->
+                val (name, hash) = line.split(GIT_FORMAT_SEPARATOR)
+                RemoteBranch(name, log(hash, 1).single())
+            }
+    }
+
+    override fun getRemoteBranchesById(): Map<String, RemoteBranch> {
+        logger.trace("getRemoteBranchesById")
+        return getRemoteBranches()
+            .filter { branch -> branch.commit.id != null }
+            .associateBy { branch -> checkNotNull(branch.commit.id) }
+    }
+
+    override fun reset(refName: String): GitClient {
+        logger.trace("reset {}", refName)
+        return apply { executeCommand(listOf("git", "reset", "--hard", refName)) }
+    }
+
+    override fun branch(name: String, startPoint: String, force: Boolean): Commit? {
+        logger.trace("branch {} start {} force {}", name, startPoint, force)
+        val old = if (refExists(name)) {
+            log(name, 1).single()
+        } else {
+            null
+        }
+        val forceOption = if (force) listOf("-f") else emptyList()
+        executeCommand(listOf("git", "branch") + forceOption + listOf(name, startPoint))
+        return old
+    }
+
+    override fun refExists(refName: String): Boolean {
+        logger.trace("refExists {}", refName)
+        // Using --verify requires fully qualified ref names
+        // TODO eventually don't check the prefix
+        val prefixedRefName = if (refName.startsWith(GitClient.R_HEADS) || refName.startsWith(GitClient.R_REMOTES)) {
+            refName
+        } else {
+            refsHeads(refName)
+        }
+        return ProcessExecutor()
+            .directory(workingDirectory)
+            .command(listOf("git", "show-ref", "--verify", "--quiet", prefixedRefName))
+            .destroyOnExit()
+            .readOutput(true)
+            .execute()
+            .exitValue
+            .let { exitValue -> exitValue == 0 }
+    }
+
+    override fun deleteBranches(names: List<String>, force: Boolean): List<String> {
+        val filteredNames = names.filter { name -> refExists(name) }
+        logger.trace("deleteBranches {} {}", names, force)
+        if (filteredNames.isNotEmpty()) {
+            val forceOption = if (force) listOf("-D") else listOf("-d")
+            executeCommand(listOf("git", "branch") + forceOption + filteredNames)
+        }
+        return names
+    }
+
+    override fun add(filePattern: String): GitClient = apply {
+        logger.trace("add {}", filePattern)
+        executeCommand(listOf("git", "add", filePattern))
+    }
+
+    override fun setCommitId(commitId: String) {
+        logger.trace("setCommitId {}", commitId)
+        val head = log("HEAD", 1).single()
+        require(!CommitParsers.getFooters(head.fullMessage).containsKey("commit-id")) {
+            "Commit already has a commit-id footer: $head"
+        }
+        executeCommand(
+            listOf(
+                "git",
+                "commit",
+                "--amend",
+                "-m",
+                CommitParsers.addFooters(head.fullMessage, mapOf(COMMIT_ID_LABEL to commitId)),
+            ),
+        )
+    }
+
+    override fun commit(message: String, footerLines: Map<String, String>, commitIdent: Ident?): Commit {
+        logger.trace("commit {} {}", message, footerLines)
+        val configFile = commitIdent?.let(::writeIdentGitConfigFile)
+        executeCommand(
+            listOf(
+                "git",
+                "commit",
+                "-m",
+                CommitParsers.addFooters(message, footerLines),
+            ),
+            if (configFile != null) mapOf("GIT_CONFIG_GLOBAL" to configFile.absolutePath) else emptyMap(),
+        )
+        return log("HEAD", 1).single()
+    }
+
+    private fun writeIdentGitConfigFile(ident: Ident): File {
+        val tempDir = checkNotNull(Files.createTempDirectory(CliGitClient::class.java.simpleName).toFile())
+        val configFile = tempDir.resolve("git-config")
+        return configFile
+            .apply {
+                writeText(
+                    """
+[user]
+    name = ${ident.name}
+    email = ${ident.email}
+
+                    """.trimIndent(),
+                )
+            }
+            .also {
+                logger.info("Wrote git config file to {}", it)
+            }
+    }
+
+    override fun cherryPick(commit: Commit): Commit {
+        logger.trace("cherryPick {}", commit)
+        executeCommand(listOf("git", "cherry-pick", commit.hash))
+        return log("HEAD", 1).single()
+    }
+
+    override fun push(refSpecs: List<RefSpec>) {
+        logger.trace("push {}", refSpecs)
+        val filteredRefSpecs = refSpecs
+            .filterNot { refSpec ->
+                // Cli push doesn't like it when you try to force push a branch that doesn't exist
+                // Since we want it deleted anyway, don't complain, just filter it out
+                refSpec.localRef == FORCE_PUSH_PREFIX && !refExists(refsRemotes(refSpec.remoteRef))
+            }
+            .map { refSpec ->
+                // In this context we want to use the full ref name, so we can push HEAD to new branches
+                refSpec.copy(remoteRef = refsHeads(refSpec.remoteRef))
+            }
+        if (filteredRefSpecs != refSpecs) {
+            logger.trace("Filtered refSpecs to {}", filteredRefSpecs)
+        }
+        if (filteredRefSpecs.isEmpty()) {
+            logger.info("No refSpecs to push")
+        } else {
+            executeCommand(
+                listOf(
+                    "git",
+                    "push",
+                    "origin",
+                    "--atomic",
+                ) + filteredRefSpecs.map(RefSpec::toString),
+            )
+        }
+    }
+
+    override fun getRemoteUriOrNull(remoteName: String): String? =
+        executeCommand(listOf("git", "remote", "get-url", remoteName))
+            .output
+            .string
+            .trim()
+            .takeIf(String::isNotBlank)
+
+    private fun gitLog(vararg logArg: String): List<Commit> {
+        // Thanks to https://www.nushell.sh/cookbook/parsing_git_log.html for inspiration here
+        val prettyFormat = listOf(
+            "--pretty=format:%h", // hash
+            "%s", // subject
+            "%cN", // commit name
+            "%cE", // commit email
+            "%(trailers:key=commit-id,separator=$GIT_LOG_TRAILER_SEPARATOR,valueonly=true)", // trailers
+            "%ct", // commit timestamp
+            "%at", // author timestamp
+            "%B", // raw body (subject + body)
+        )
+            .joinToString(GIT_FORMAT_SEPARATOR)
+
+        return executeCommand(listOf("git", "log") + logArg.toList() + listOf("-z", prettyFormat))
+            .output
+            .string
+            .split('\u0000')
+            .filter(String::isNotBlank)
+            .map(CommitParsers::parseCommitLogEntry)
+    }
+
+    private fun executeCommand(command: List<String>, environment: Map<String, String> = emptyMap()): ProcessResult {
+        return ProcessExecutor()
+            .directory(workingDirectory)
+            .environment(environment)
+            .command(command)
+            .destroyOnExit()
+            .readOutput(true)
+            .execute()
+            .also(ProcessResult::requireZeroExitValue)
+    }
+
+    companion object {
+        const val GIT_FORMAT_SEPARATOR = "»¦«"
+        const val GIT_LOG_TRAILER_SEPARATOR = "{^}"
+    }
+}
+
+private fun ProcessResult.requireZeroExitValue() {
+    val exitValue = exitValue
+    require(exitValue == 0) { "Command returned $exitValue: ${output.string}" }
+}

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CommitParsers.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CommitParsers.kt
@@ -1,6 +1,37 @@
 package sims.michael.gitjaspr
 
+import sims.michael.gitjaspr.CliGitClient.Companion.GIT_FORMAT_SEPARATOR
+import sims.michael.gitjaspr.CliGitClient.Companion.GIT_LOG_TRAILER_SEPARATOR
+import java.time.Instant
+import java.time.ZoneId
+
 object CommitParsers {
+
+    fun parseCommitLogEntry(logEntry: String): Commit {
+        val split = logEntry.split(GIT_FORMAT_SEPARATOR)
+        check(split.size == 8) {
+            "Log entry is in unexpected format: $logEntry"
+        }
+        val (firstChunk, secondChunk) = split.chunked(5)
+        val (hash, shortMessage, committerName, committerEmail, commitIds) = firstChunk
+        val (commitTimestamp, authorTimestamp, fullMessage) = secondChunk
+
+        fun String.timestampToZonedDateTime() = Instant
+            .ofEpochSecond(toLong())
+            .atZone(ZoneId.systemDefault())
+            .canonicalize()
+
+        return Commit(
+            hash,
+            shortMessage,
+            fullMessage,
+            commitIds.split(GIT_LOG_TRAILER_SEPARATOR).last().takeUnless(String::isBlank),
+            Ident(committerName, committerEmail),
+            commitTimestamp.timestampToZonedDateTime(),
+            authorTimestamp.timestampToZonedDateTime(),
+        )
+    }
+
     fun addFooters(fullMessage: String, footers: Map<String, String>): String {
         val existingFooters = getFooters(fullMessage)
         return if (existingFooters.isNotEmpty()) {

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Git.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Git.kt
@@ -26,3 +26,7 @@ fun generateUuid(length: Int = 8): String {
     val (eight, twelve) = requireNotNull("(.{8})(?:-.{4}){3}-(.{12})".toRegex().matchEntire(fullUuid)).destructured
     return (eight + twelve).take(length)
 }
+
+fun refsHeads(branch: String) = if (!branch.startsWith(GitClient.R_HEADS)) "${GitClient.R_HEADS}$branch" else branch
+fun refsRemotes(branch: String, remote: String = DEFAULT_REMOTE_NAME) =
+    if (!branch.startsWith(GitClient.R_REMOTES)) "${GitClient.R_REMOTES}$remote/$branch" else branch

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
@@ -8,7 +8,7 @@ interface GitClient {
     val remoteBranchPrefix: String
     fun init(): GitClient
     fun checkout(refName: String): GitClient
-    fun clone(uri: String): GitClient
+    fun clone(uri: String, bare: Boolean = false): GitClient
     fun fetch(remoteName: String)
     fun log(): List<Commit>
     fun log(revision: String, maxCount: Int = -1): List<Commit>
@@ -26,8 +26,10 @@ interface GitClient {
     fun deleteBranches(names: List<String>, force: Boolean = false): List<String>
     fun add(filePattern: String): GitClient
     fun setCommitId(commitId: String)
-    fun commit(message: String, footerLines: Map<String, String> = emptyMap()): Commit
+    fun commit(message: String, footerLines: Map<String, String> = emptyMap(), commitIdent: Ident? = null): Commit
     fun cherryPick(commit: Commit): Commit
+
+    // TODO this should accept the remote to push to!
     fun push(refSpecs: List<RefSpec>)
     fun getRemoteUriOrNull(remoteName: String): String?
 

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -107,7 +107,7 @@ class GitJaspr(
 
         val existingPrsByCommitId = pullRequestsRebased.associateBy(PullRequest::commitId)
 
-        val isDraftRegex = "^draft\\b.*$".toRegex(IGNORE_CASE)
+        val isDraftRegex = "^(draft|wip)\\b.*$".toRegex(IGNORE_CASE)
         val prsToMutate = stack
             .windowedPairs()
             .map { (prevCommit, currentCommit) ->

--- a/git-jaspr/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/git-jaspr/src/main/resources/META-INF/native-image/reflect-config.json
@@ -710,6 +710,10 @@
   "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"<init>","parameterTypes":["java.security.SecureRandomParameters"] }]
 },
 {
+  "name":"sun.security.provider.NativePRNG$NonBlocking",
+  "methods":[{"name":"<init>","parameterTypes":[] }, {"name":"<init>","parameterTypes":["java.security.SecureRandomParameters"] }]
+},
+{
   "name":"sun.security.provider.SHA",
   "methods":[{"name":"<init>","parameterTypes":[] }]
 },

--- a/git-jaspr/src/main/resources/META-INF/native-image/resource-config.json
+++ b/git-jaspr/src/main/resources/META-INF/native-image/resource-config.json
@@ -57,6 +57,6 @@
   }]},
   "bundles":[{
     "name":"org.eclipse.jgit.internal.JGitText",
-    "locales":["", "und"]
+    "locales":["und"]
   }]
 }

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliGitClientTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliGitClientTest.kt
@@ -1,0 +1,705 @@
+package sims.michael.gitjaspr
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.slf4j.LoggerFactory
+import sims.michael.gitjaspr.RemoteRefEncoding.buildRemoteRef
+import sims.michael.gitjaspr.githubtests.GitHubTestHarness.Companion.withTestSetup
+import sims.michael.gitjaspr.githubtests.generatedtestdsl.testCase
+import sims.michael.gitjaspr.testing.toStringWithClickableURI
+import java.nio.file.Files
+
+class CliGitClientTest {
+
+    private val logger = LoggerFactory.getLogger(CliGitClientTest::class.java)
+
+    @Test
+    fun `compare logAll`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "some-other-branch"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(cliGit.logAll(), git.logAll())
+        }
+    }
+
+    @Test
+    fun `compare log`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "some-other-branch"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(cliGit.log(), git.log())
+        }
+    }
+
+    @Test
+    fun `compare log with count`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "some-other-branch"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(cliGit.log("some-other-branch", 2), git.log("some-other-branch", 2))
+        }
+    }
+
+    @Test
+    fun `compare log with default count`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "some-other-branch"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(cliGit.log("some-other-branch"), git.log("some-other-branch"))
+        }
+    }
+
+    @Test
+    fun `compare logRange`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "some-other-branch"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(cliGit.logRange("main", "some-other-branch"), git.logRange("main", "some-other-branch"))
+        }
+    }
+
+    @Test
+    fun `logRange throws when given nonexistant refs`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "some-other-branch"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            val git = CliGitClient(localGit.workingDirectory)
+            assertThrows<IllegalArgumentException> {
+                git.logRange("sam", "max")
+            }
+        }
+    }
+
+    @Test
+    fun `isWorkingDirectoryClean returns expected value`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "some-other-branch"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            val readme = localRepo.resolve("README.txt")
+            check(readme.exists())
+            readme.appendText("This is a change")
+            val git = CliGitClient(localGit.workingDirectory)
+            assertFalse(git.isWorkingDirectoryClean())
+        }
+    }
+
+    @Test
+    fun `compare getLocalCommitStack`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "main"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            remoteRefs += "main"
+                        }
+                    }
+                },
+            )
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(
+                cliGit.getLocalCommitStack(DEFAULT_REMOTE_NAME, DEFAULT_TARGET_REF, DEFAULT_TARGET_REF),
+                git.getLocalCommitStack(DEFAULT_REMOTE_NAME, DEFAULT_TARGET_REF, DEFAULT_TARGET_REF),
+            )
+        }
+    }
+
+    @Test
+    fun `compare getParents`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "main"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            remoteRefs += "main"
+                        }
+                    }
+                },
+            )
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val main = cliGit.log(DEFAULT_TARGET_REF, 1).single()
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(
+                cliGit.getParents(main),
+                git.getParents(main),
+            )
+        }
+    }
+
+    @Test
+    fun `compare getBranches`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "development"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            remoteRefs += "main"
+                        }
+                    }
+                },
+            )
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(
+                cliGit.getBranchNames(),
+                git.getBranchNames(),
+            )
+        }
+    }
+
+    @Test
+    fun `compare getRemoteBranches`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit { title = "a" }
+                                commit { title = "b" }
+                                commit { title = "c" }
+                                commit {
+                                    title = "d"
+                                    localRefs += "development"
+                                }
+                            }
+                        }
+                        commit { title = "two" }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            remoteRefs += "main"
+                        }
+                    }
+                },
+            )
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(
+                cliGit.getRemoteBranches(),
+                git.getRemoteBranches(),
+            )
+        }
+    }
+
+    @Test
+    fun `compare getRemoteBranchesById`() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            branch {
+                                commit {
+                                    title = "a"
+                                    localRefs += buildRemoteRef("a")
+                                }
+                                commit {
+                                    title = "b"
+                                    localRefs += buildRemoteRef("b")
+                                }
+                                commit {
+                                    title = "c"
+                                    localRefs += buildRemoteRef("c")
+                                }
+                                commit {
+                                    title = "d"
+                                    localRefs += buildRemoteRef("d")
+                                }
+                            }
+                        }
+                        commit {
+                            title = "two"
+                            localRefs += buildRemoteRef("two")
+                        }
+                        commit {
+                            title = "three"
+                            body = "This is a body"
+                            remoteRefs += buildRemoteRef("three")
+                        }
+                    }
+                },
+            )
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(
+                cliGit.getRemoteBranchesById(),
+                git.getRemoteBranchesById(),
+            )
+        }
+    }
+
+    @Test
+    fun `compare getRemoteUriOrNull`() {
+        withTestSetup {
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(
+                cliGit.getRemoteUriOrNull(DEFAULT_REMOTE_NAME),
+                git.getRemoteUriOrNull(DEFAULT_REMOTE_NAME),
+            )
+        }
+    }
+
+    @Test
+    fun testInit() {
+        withTestSetup {
+            val git = CliGitClient(localGit.workingDirectory.resolve("new-repo"))
+            git.init()
+            assertTrue(localGit.workingDirectory.resolve(".git").exists())
+        }
+    }
+
+    @Test
+    fun testCheckout() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            localRefs += "development"
+                        }
+                    }
+                },
+            )
+            val git = CliGitClient(localGit.workingDirectory)
+            git.checkout("development")
+            assertEquals("one", git.log("HEAD", 1).single().shortMessage)
+            git.checkout("main")
+        }
+    }
+
+    @Test
+    fun testClone() {
+        withTestSetup {
+            val cloneDirectory = scratchDir.resolve("cloned")
+            val git = CliGitClient(cloneDirectory)
+            git.clone(localRepo.absolutePath)
+            assertTrue(cloneDirectory.resolve(".git").exists())
+        }
+    }
+
+    @Test
+    fun testCloneUri() {
+        withTestSetup {
+            val cloneDirectory = scratchDir.resolve("cloned")
+            val git = CliGitClient(cloneDirectory)
+            git.clone(localRepo.toURI().toString())
+            assertTrue(cloneDirectory.resolve(".git").exists())
+        }
+    }
+
+    @Test
+    fun testFetch() {
+        val tempDir = checkNotNull(Files.createTempDirectory(CliGitClientTest::class.java.simpleName).toFile())
+            .also { logger.info("Temp dir created in {}", it.toStringWithClickableURI()) }
+        val remoteDir = tempDir.resolve("remote")
+        val remoteGit = CliGitClient(remoteDir).init()
+        remoteDir.resolve("README.txt").writeText("This is a README")
+        remoteGit.add("README.txt").commit("This is a README")
+        val localGit = CliGitClient(tempDir.resolve("local")).clone(remoteDir.absolutePath)
+        val newFile = remoteGit.workingDirectory.resolve("NEW.txt")
+        newFile.appendText("This is a new file")
+        remoteGit.add("NEW.txt").commit("Add new file")
+        val git = CliGitClient(localGit.workingDirectory)
+        git.fetch(DEFAULT_REMOTE_NAME)
+        assertEquals("Add new file", git.log("origin/main", 1).single().shortMessage)
+    }
+
+    @Test
+    fun testReset() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                        }
+                        commit {
+                            title = "two"
+                        }
+                        commit {
+                            title = "three"
+                            localRefs += "development"
+                        }
+                    }
+                },
+            )
+            val git = CliGitClient(localGit.workingDirectory)
+            git.reset("development~1")
+            assertEquals("two", git.log("HEAD", 1).single().shortMessage)
+        }
+    }
+
+    @Test
+    fun testBranch() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                        }
+                        commit {
+                            title = "two"
+                        }
+                        commit {
+                            title = "three"
+                            localRefs += "development"
+                        }
+                    }
+                },
+            )
+            val git = CliGitClient(localGit.workingDirectory)
+            git.branch("new-branch", "development^")
+            assertEquals("two", git.log("new-branch", 1).single().shortMessage)
+        }
+    }
+
+    @Test
+    fun testDeleteBranches() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                        }
+                        commit {
+                            title = "two"
+                        }
+                        commit {
+                            title = "three"
+                            localRefs += "development"
+                        }
+                    }
+                },
+            )
+            val git = CliGitClient(localGit.workingDirectory)
+            git.deleteBranches(listOf("development"))
+            assertFalse(git.getBranchNames().contains("development"))
+        }
+    }
+
+    @Test
+    fun testDeleteBranchesEmpty() {
+        withTestSetup {
+            val git = CliGitClient(localGit.workingDirectory)
+            git.deleteBranches(emptyList())
+        }
+    }
+
+    @Test
+    fun testAddAndCommit() {
+        withTestSetup {
+            val newFile = localGit.workingDirectory.resolve("NEW.txt")
+            newFile.appendText("This is a new file")
+            val git = CliGitClient(localGit.workingDirectory)
+            git.add("NEW.txt")
+            git.commit(
+                """
+Add new file
+
+This is a commit body
+
+                """.trimIndent(),
+                mapOf("Co-authored-by" to "Michael Sims"),
+            )
+            assertTrue(git.isWorkingDirectoryClean())
+        }
+    }
+
+    @Test
+    fun testPush() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            localRefs += "development"
+                        }
+                    }
+                },
+            )
+            val git = CliGitClient(localGit.workingDirectory)
+            git.push(listOf(RefSpec("development", "main")))
+            assertEquals("one", remoteGit.log("main", 1).single().shortMessage)
+        }
+    }
+
+    @Test
+    fun testCherryPick() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                        }
+                        commit {
+                            title = "two"
+                        }
+                        commit {
+                            title = "three"
+                            localRefs += "development"
+                        }
+                    }
+                },
+            )
+            val git = CliGitClient(localGit.workingDirectory)
+            git.checkout("main")
+            git.cherryPick(localGit.log("development~1", 1).single())
+            assertEquals("two", git.log("HEAD", 1).single().shortMessage)
+        }
+    }
+
+    @Test
+    fun testSetCommitId() {
+        withTestSetup {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            id = ""
+                            localRefs += "development"
+                        }
+                    }
+                },
+            )
+            val git = CliGitClient(localGit.workingDirectory)
+            git.setCommitId("newCommitId")
+            assertEquals("newCommitId", git.log("HEAD", 1).single().id)
+        }
+    }
+
+    @Test
+    fun testRefExists() {
+        withTestSetup {
+            val git = CliGitClient(localGit.workingDirectory)
+            assertTrue(git.refExists("main"))
+            assertFalse(git.refExists("nonexistent"))
+        }
+    }
+}

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -1121,7 +1121,11 @@ commit-id: 0
                             id = "a"
                         }
                         commit {
-                            title = "b"
+                            title = "wip b"
+                            id = "b"
+                        }
+                        commit {
+                            title = "c"
                             localRefs += "development"
                         }
                     }
@@ -1130,7 +1134,7 @@ commit-id: 0
             push()
 
             assertEquals(
-                listOf(true, false),
+                listOf(true, true, false),
                 gitHub.getPullRequests().map(PullRequest::isDraft),
             )
         }


### PR DESCRIPTION
Push draft PRs for commit subjects that start with "wip" too

For https://github.com/MichaelSims/git-jaspr/issues/122

**Stack**:
- #128 ⬅
- #126
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I5f8995bd_01..jaspr/main/I5f8995bd)
- #125
- #120
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_02..jaspr/main/I31acaa43), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_01..jaspr/main/I31acaa43_02)
- #124

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
