### PR TITLE
Push draft PRs for commit subjects that start with "wip" too

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -107,7 +107,7 @@ class GitJaspr(
 
         val existingPrsByCommitId = pullRequestsRebased.associateBy(PullRequest::commitId)
 
-        val isDraftRegex = "^draft\\b.*$".toRegex(IGNORE_CASE)
+        val isDraftRegex = "^(draft|wip)\\b.*$".toRegex(IGNORE_CASE)
         val prsToMutate = stack
             .windowedPairs()
             .map { (prevCommit, currentCommit) ->

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -1121,7 +1121,11 @@ commit-id: 0
                             id = "a"
                         }
                         commit {
-                            title = "b"
+                            title = "wip b"
+                            id = "b"
+                        }
+                        commit {
+                            title = "c"
                             localRefs += "development"
                         }
                     }
@@ -1130,7 +1134,7 @@ commit-id: 0
             push()
 
             assertEquals(
-                listOf(true, false),
+                listOf(true, true, false),
                 gitHub.getPullRequests().map(PullRequest::isDraft),
             )
         }


### PR DESCRIPTION
Push draft PRs for commit subjects that start with "wip" too

For https://github.com/MichaelSims/git-jaspr/issues/122

**Stack**:
- #125
  - [12..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_12..jaspr/main/I2d8e130b), [11..12](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_11..jaspr/main/I2d8e130b_12), [10..11](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_10..jaspr/main/I2d8e130b_11), [09..10](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_09..jaspr/main/I2d8e130b_10), [08..09](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_08..jaspr/main/I2d8e130b_09), [07..08](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_07..jaspr/main/I2d8e130b_08), [06..07](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_06..jaspr/main/I2d8e130b_07), [05..06](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_05..jaspr/main/I2d8e130b_06), [04..05](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_04..jaspr/main/I2d8e130b_05), [03..04](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_03..jaspr/main/I2d8e130b_04), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_02..jaspr/main/I2d8e130b_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I2d8e130b_01..jaspr/main/I2d8e130b_02)
- #120
  - [13..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_13..jaspr/main/I31acaa43), [12..13](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_12..jaspr/main/I31acaa43_13), [11..12](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_11..jaspr/main/I31acaa43_12), [10..11](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_10..jaspr/main/I31acaa43_11), [09..10](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_09..jaspr/main/I31acaa43_10), [08..09](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_08..jaspr/main/I31acaa43_09), [07..08](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_07..jaspr/main/I31acaa43_08), [06..07](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_06..jaspr/main/I31acaa43_07), [05..06](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_05..jaspr/main/I31acaa43_06), [04..05](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_04..jaspr/main/I31acaa43_05), [03..04](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_03..jaspr/main/I31acaa43_04), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_02..jaspr/main/I31acaa43_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I31acaa43_01..jaspr/main/I31acaa43_02)
- #133
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Id74afd31_02..jaspr/main/Id74afd31), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Id74afd31_01..jaspr/main/Id74afd31_02)
- #132 ⬅
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I63183646_03..jaspr/main/I63183646), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I63183646_02..jaspr/main/I63183646_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I63183646_01..jaspr/main/I63183646_02)
- #126
  - [04..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I5f8995bd_04..jaspr/main/I5f8995bd), [03..04](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I5f8995bd_03..jaspr/main/I5f8995bd_04), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I5f8995bd_02..jaspr/main/I5f8995bd_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I5f8995bd_01..jaspr/main/I5f8995bd_02)

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
