### PR TITLE
Jaspr does not merge out of date commits

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
@@ -17,6 +17,7 @@ import org.eclipse.jgit.transport.RemoteRefUpdate
 import org.eclipse.jgit.transport.SshSessionFactory
 import org.eclipse.jgit.transport.ssh.jsch.JschConfigSessionFactory
 import org.slf4j.LoggerFactory
+import sims.michael.gitjaspr.RemoteRefEncoding.getRemoteRefParts
 import java.io.File
 import java.time.Instant
 import java.time.ZoneId
@@ -171,8 +172,9 @@ class JGitClient(
         logger.trace("getRemoteBranchesById")
         return getRemoteBranches()
             .mapNotNull { branch ->
-                val commitId = RemoteRefEncoding.getCommitIdFromRemoteRef(branch.name, remoteBranchPrefix)
-                if (commitId != null) commitId to branch else null
+                getRemoteRefParts(branch.name, remoteBranchPrefix)
+                    ?.takeIf { parts -> parts.revisionNum == null } // Filter history branches
+                    ?.let { it.commitId to branch }
             }
             .toMap()
     }


### PR DESCRIPTION
Jaspr does not merge out of date commits

Also, fix bug where getRemoteBranchesById was not filtering out history
branches (and the CLI implementation was just straight up broken).

**Stack**:
- #140
- #139
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I4ccb9c9b_01..jaspr/main/I4ccb9c9b)
- #138 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I632aef3f_01..jaspr/main/I632aef3f)

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
