### PR TITLE
Avoid unnecessary PR updates when things haven't changed

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -186,13 +186,41 @@ abstract class GitJasprCommand(help: String = "", hidden: Boolean = false) :
         }
     }
 
-    private val githubToken by option(envvar = GITHUB_TOKEN_ENV_VAR).required().help {
-        """
+    private val missingTokenMessage = """
+Hello! First time running Jaspr?
+
+We couldn't find your GitHub PAT (personal access token).
+You need to create one with read:org, read:user, repo,
+and user:email permissions and provide it via one of
+the following methods:
+
+- Create a file named $CONFIG_FILE_NAME in your home
+  directory with the following contents:
+    githubToken=<your token here>
+- Create a file named $CONFIG_FILE_NAME in your working
+  directory with the following contents:
+    githubToken=<your token here>
+- Set the environment variable $GITHUB_TOKEN_ENV_VAR to
+  your token
+
+⚠️  NOTE ⚠️ : Please remember to enable SSO on your token 
+if applicable. If in the future you change the scope of an
+existing token, it will disable the SSO authorization so
+you'll need to re-enable it again.
+    """.trimIndent()
+
+    private val githubToken by option(envvar = GITHUB_TOKEN_ENV_VAR)
+        .transformAll(showAsRequired = true) { stringList ->
+            stringList.lastOrNull()
+                ?: throw PrintMessage(message = missingTokenMessage, statusCode = 1, printError = true)
+        }
+        .help {
+            """
         A GitHub PAT (personal access token) with read:org, read:user, repo, and user:email permissions. Can be provided 
         via the per-user config file, a per-working copy config file, or the environment variable 
         $GITHUB_TOKEN_ENV_VAR.
-        """.trimIndent()
-    }
+            """.trimIndent()
+        }
 
     private val gitHubOptions by GitHubOptions()
 


### PR DESCRIPTION
Avoid unnecessary PR updates when things haven't changed

In the prior code, the PR bodies were always different because they
didn't contain stack information in the descriptions. With this change
we only update the PRs if necessary

**Stack**:
- #144 ⬅
- #142
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I79a0e1d3_01..jaspr/main/I79a0e1d3)

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
