### PR TITLE
Fix ISE when running status on a stack with commits missing IDs

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -32,6 +32,7 @@ class GitJaspr(
 
         val statuses = getRemoteCommitStatuses(stack)
         val commitsWithDuplicateIds = statuses
+            .filter { status -> status.localCommit.id != null }
             .groupingBy { status -> checkNotNull(status.localCommit.id) }
             .aggregate { _, accumulator: List<RemoteCommitStatus>?, element, _ ->
                 (accumulator ?: emptyList()) + element
@@ -45,7 +46,7 @@ class GitJaspr(
                 append("[")
                 val statusBits = StatusBits(
                     commitIsPushed = when {
-                        commitsWithDuplicateIds.containsKey(checkNotNull(status.localCommit.id)) -> WARNING
+                        commitsWithDuplicateIds.containsKey(status.localCommit.id) -> WARNING
                         status.remoteCommit == null -> EMPTY
                         status.remoteCommit.hash != status.localCommit.hash -> WARNING
                         else -> SUCCESS
@@ -112,6 +113,7 @@ class GitJaspr(
         val stack = addCommitIdsToLocalStack(getLocalCommitStack()) ?: getLocalCommitStack()
 
         val commitsWithDuplicateIds = stack
+            .filter { it.id != null }
             .groupingBy { checkNotNull(it.id) }
             .aggregate { _, accumulator: List<Commit>?, element, _ ->
                 (accumulator ?: emptyList()) + element

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -810,6 +810,34 @@ interface GitJasprTest {
             )
         }
     }
+
+    // Test for a bug that was occurring when the stack had commits without ids
+    @Test
+    fun `status without commit IDs does not crash`() {
+        withTestSetup(useFakeRemote) {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            id = ""
+                        }
+                        commit {
+                            title = "two"
+                            id = ""
+                        }
+                        commit {
+                            title = "three"
+                            id = ""
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            logger.info(gitJaspr.getStatusString())
+        }
+    }
     //endregion
 
     //region push tests


### PR DESCRIPTION
Fix ISE when running status on a stack with commits missing IDs

**Stack**:
- #145 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
