### PR TITLE
Fix bug where commit ID was being added without a blank line before it

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CommitParsers.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CommitParsers.kt
@@ -45,9 +45,15 @@ object CommitParsers {
         val fullMessageTrimmed = fullMessage.trim()
         val maybeFooterSection = fullMessageTrimmed.substringAfterLast("\n\n")
         if (maybeFooterSection == fullMessageTrimmed) return emptyMap() // Just a subject
-        val maybeFooterLines = maybeFooterSection.lines().map { line -> line.split("\\s*:\\s*".toRegex()) }
-        return if (maybeFooterLines.all { list -> list.size == 2 }) {
-            maybeFooterLines.associate { (k, v) -> k to v }
+
+        val footerLineRegex = "^([^\\s:]+): ([^\\s:]+)$".toRegex()
+
+        val maybeFooterLines = maybeFooterSection.lines()
+        return if (maybeFooterLines.all { line -> footerLineRegex.matches(line) }) {
+            maybeFooterLines.associate { line ->
+                val (key, value) = line.split(":")
+                key.trim() to value.trim()
+            }
         } else {
             emptyMap()
         }

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CommitParsersTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CommitParsersTest.kt
@@ -52,6 +52,19 @@ class CommitParsersTest {
     }
 
     @Test
+    fun `getFooters - subject, body url that could look like a footer line if your code was bad`() {
+        val message = """
+            This is a subject
+
+            See this Slack thread:
+            https://trillianthealth.slack.com/archives/C04J6Q655GR/p1702918943374039?thread_ts=1702918322.439999&cid=C04J6Q655GR
+
+        """.trimIndent()
+
+        assertEquals(emptyMap(), getFooters(message))
+    }
+
+    @Test
     fun `getFooters - subject, body, existing footer lines`() {
         val message = """
             This is a subject

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -906,6 +906,44 @@ interface GitJasprTest {
     }
 
     @Test
+    fun `add footers does not consider a trailing URL a footer line`() {
+        // assert the absence of a bug where a URL was being interpreted as a footer line
+        withTestSetup(useFakeRemote, rollBackChanges = false) {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "Fix end of year data issue [providerDir]"
+                            body = """
+See this Slack thread:
+https://trillianthealth.slack.com/archives/C04J6Q655GR/p1702918943374039?thread_ts=1702918322.439999&cid=C04J6Q655GR
+
+                            """.trimMargin()
+                            id = ""
+                            localRefs += "main"
+                        }
+                    }
+                },
+            )
+
+            push()
+
+            assertEquals(
+                """
+Fix end of year data issue [providerDir]
+
+See this Slack thread:
+https://trillianthealth.slack.com/archives/C04J6Q655GR/p1702918943374039?thread_ts=1702918322.439999&cid=C04J6Q655GR
+
+commit-id: 0
+
+                """.trimIndent(),
+                localGit.log("HEAD", maxCount = 1).single().fullMessage,
+            )
+        }
+    }
+
+    @Test
     fun `commit ID is added with a blank line before it`() {
         withTestSetup(useFakeRemote) {
             createCommitsFrom(


### PR DESCRIPTION
Fix bug where commit ID was being added without a blank line before it

**Stack**:
- #148
- #147 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
