### PR TITLE
Add a section to the README.md about GitHub branch protection rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,19 @@ Any of the above can be invoked with `--help` (except just `git jaspr` which req
 into).
 
 Enjoy!
+
+## Note on GitHub branch protection rules and rulesets
+
+GitHub branch protection rules and rulesets are both complex features, and I won't pretend to be an expert. There are
+many configurations that are likely valid, so ultimately what works, works. But there are some considerations to keep in
+mind with regard to using Jaspr:
+
+- At a minimum you should have a workflow that triggers on pull requests (either for all branches or at least for `main`
+  and for `jaspr/**/*`) that runs checks and reports status back to GitHub. Likely you want a branch protection rule
+  that requires status checks to pass before merging to `main` at least.
+- If `git jaspr status` does not show the "pr approved" checkmark or x, you may need to create a branch protection rule
+  that requires pull request approvals before merging first. (I've noticed this behavior is inconsistent... sometimes
+  this bit shows even without this requirement.)
+- You want to make sure that people can force push to `jspr/**/*`. Jaspr's philosophy is that of Gerrit's, which is to
+  favor a trunk based workflow where PR remediation is done via amends/edits and are force pushed (this is why Jaspr
+  pushes revision history branches and includes diff links for them in the PR descriptions).


### PR DESCRIPTION
Add a section to the README.md about GitHub branch protection rules

For https://github.com/MichaelSims/git-jaspr/issues/29

**Stack**:
- #157
- #156
- #155
- #154
- #153
- #152
- #151
- #150 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
