### PR TITLE
Fix punctuation in comment

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -266,7 +266,7 @@ class GitJaspr(
             ghClient.updatePullRequest(pr)
         }
 
-        // Do this cleanup separately after we've rebased remaining PRs. Otherwise if we delete a branch that's the
+        // Do this cleanup separately after we've rebased remaining PRs. Otherwise, if we delete a branch that's the
         // base ref for a current PR, GitHub will implicitly close it.
         logger.info("Cleaning up {} {}.", branchesToDelete.size, branchOrBranches(branchesToDelete.size))
         gitClient.push(branchesToDelete)


### PR DESCRIPTION
Fix punctuation in comment

**Stack**:
- #157
- #156
- #155 ⬅
- #154
- #153
- #152
- #151
- #150

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
