### PR TITLE
Bump gradle/gradle-build-action from 2.10.0 to 2.11.0

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -63,7 +63,7 @@ jobs:
           java-version: "11.0.21-zulu"
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@87a9a15658c426a54dd469d4fc7dc1a73ca9d4a6 # v2.10.0
+        uses: gradle/gradle-build-action@8cbcb9948b5892387aed077daf6f90e1f0ba5b27 # v2.11.0
 
       - name: Run Tests
         run: ./gradlew build --configure-on-demand --max-workers=4


### PR DESCRIPTION
Bump gradle/gradle-build-action from 2.10.0 to 2.11.0

Bumps [gradle/gradle-build-action](https://github.com/gradle/gradle-build-action) from 2.10.0 to 2.11.0.
- [Release notes](https://github.com/gradle/gradle-build-action/releases)
- [Commits](https://github.com/gradle/gradle-build-action/compare/87a9a15658c426a54dd469d4fc7dc1a73ca9d4a6...8cbcb9948b5892387aed077daf6f90e1f0ba5b27)

commit-id: I5369b5e8

---
updated-dependencies:
- dependency-name: gradle/gradle-build-action
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

**Stack**:
- #null
- #null ⬅
- #null
- #null
- #null
- #null
- #151
- #150

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
