### PR TITLE
FIX: Do not explicitly close the HEAD pr of a merging stack

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -252,7 +252,7 @@ class GitJaspr(
         gitClient.push(refSpecs)
         logger.info("Merged {} {} to {}", indexLastMergeable + 1, refOrRefs(indexLastMergeable + 1), refSpec.remoteRef)
 
-        val prsToClose = statuses.slice(0..indexLastMergeable).mapNotNull(RemoteCommitStatus::pullRequest)
+        val prsToClose = statuses.slice(0 until indexLastMergeable).mapNotNull(RemoteCommitStatus::pullRequest)
         for (pr in prsToClose) {
             ghClient.closePullRequest(pr)
         }

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -1793,6 +1793,38 @@ E
     }
 
     @Test
+    fun `merge just one`() {
+        withTestSetup(useFakeRemote, rollBackChanges = true) {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            willPassVerification = true
+                            localRefs += "development"
+                            remoteRefs += buildRemoteRef("one")
+                        }
+                    }
+                    pullRequest {
+                        headRef = buildRemoteRef("one")
+                        baseRef = "main"
+                        title = "one"
+                        willBeApprovedByUserKey = "michael"
+                    }
+                },
+            )
+
+            waitForChecksToConclude("one")
+            merge(RefSpec("development", "main"))
+
+            assertEquals(
+                emptyList(),
+                localGit.getLocalCommitStack(DEFAULT_REMOTE_NAME, "development", DEFAULT_TARGET_REF),
+            )
+        }
+    }
+
+    @Test
     fun `autoMerge happy path`() {
         withTestSetup(useFakeRemote) {
             createCommitsFrom(


### PR DESCRIPTION
FIX: Do not explicitly close the HEAD pr of a merging stack

This will properly show that the PR was merged instead of closed, which
makes it sort of look like something went wrong.

**Stack**:
- #163
- #162 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
