### PR TITLE
Make GitHubStubClient's PR state consistent at the end of a merge

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitHubClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitHubClient.kt
@@ -25,6 +25,7 @@ interface GitHubClient {
     suspend fun updatePullRequest(pullRequest: PullRequest)
     suspend fun closePullRequest(pullRequest: PullRequest)
     suspend fun approvePullRequest(pullRequest: PullRequest)
+    fun autoClosePrs()
 }
 
 class GitHubClientImpl(
@@ -250,6 +251,10 @@ class GitHubClientImpl(
             .also { response ->
                 response.checkNoErrors { logger.error("Error approving PR #{}", pullRequest.number) }
             }
+    }
+
+    override fun autoClosePrs() {
+        // No-op: only the stub client needs to do this
     }
 
     private suspend fun fetchRepositoryId(gitHubInfo: GitHubInfo): String {

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -266,6 +266,10 @@ class GitJaspr(
             ghClient.updatePullRequest(pr)
         }
 
+        // Call this for the benefit of the stub client in case we're running within tests. In production, this does
+        // nothing as GitHub will "auto close" PRs that are merged
+        ghClient.autoClosePrs()
+
         // Do this cleanup separately after we've rebased remaining PRs. Otherwise, if we delete a branch that's the
         // base ref for a current PR, GitHub will implicitly close it.
         logger.info("Cleaning up {} {}.", branchesToDelete.size, branchOrBranches(branchesToDelete.size))

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
@@ -90,7 +90,7 @@ class GitHubStubClient(private val remoteBranchPrefix: String, private val local
 
     // Mimic GitHub's behavior since our program logic depends on it. Should be called from any method that returns
     // PRs so that the PR state is always viewed consistently with the git repo state
-    private fun autoClosePrs() {
+    override fun autoClosePrs() {
         logger.trace("autoClosePrs")
         val commitsById = localGit.logAll().associateBy(Commit::id)
         synchronized(prs) {


### PR DESCRIPTION
Make GitHubStubClient's PR state consistent at the end of a merge

Within tests, GitHubStubClient still has an out of date view of the PR
state after a merge because nothing explicitly asks for the PRs and
autoClosePrs doesn't get a chance to get invoked. I could have it
triggered by all calls to create or update PRs as well, but it's already
very slow when running with the CliGitClient, so I'd rather have an
explicit call to it within the merge function and promote it to the
interface and have the production implementation do nothing.

**Stack**:
- #167
- #166
- #165
- #164 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
