### PR TITLE
Remove unused import (why didn't spotless + ktlint catch this?)

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -22,7 +22,6 @@ import com.github.ajalt.clikt.sources.ChainedValueSource
 import com.github.ajalt.clikt.sources.PropertiesValueSource
 import com.github.ajalt.clikt.sources.ValueSource.Companion.getKey
 import com.github.ajalt.mordant.rendering.TextColors
-import com.github.ajalt.mordant.rendering.TextColors.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import org.intellij.lang.annotations.Language


### PR DESCRIPTION
Remove unused import (why didn't spotless + ktlint catch this?)

**Stack**:
- #167
- #166 ⬅
- #165
- #164

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
