### PR TITLE
Remove --use-cli-git-client, use "optimized" git client across the board

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -22,7 +22,6 @@ import com.github.ajalt.clikt.sources.ChainedValueSource
 import com.github.ajalt.clikt.sources.PropertiesValueSource
 import com.github.ajalt.clikt.sources.ValueSource.Companion.getKey
 import com.github.ajalt.mordant.rendering.TextColors
-import com.github.ajalt.mordant.rendering.TextColors.*
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.encodeToString
 import org.intellij.lang.annotations.Language

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -267,18 +267,8 @@ you'll need to re-enable it again.
         }
         .default(DEFAULT_REMOTE_NAME)
 
-    private val useCliGitClient by option().flag("--no-use-cli-git-client", default = false)
-        .help {
-            "Use the CLI client instead of the JGit client. This option is slightly slower but has better " +
-                "compatibility with various SSH configurations such as OS X + ssh-agent."
-        }
-
     val appWiring by lazy {
-        val gitClient = if (useCliGitClient) {
-            CliGitClient(workingDirectory, remoteBranchPrefix)
-        } else {
-            JGitClient(workingDirectory, remoteBranchPrefix)
-        }
+        val gitClient = OptimizedCliGitClient(workingDirectory, remoteBranchPrefix)
         val githubInfo = determineGithubInfo(gitClient)
         val config = Config(
             workingDirectory,

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitHubClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitHubClient.kt
@@ -25,6 +25,7 @@ interface GitHubClient {
     suspend fun updatePullRequest(pullRequest: PullRequest)
     suspend fun closePullRequest(pullRequest: PullRequest)
     suspend fun approvePullRequest(pullRequest: PullRequest)
+    fun autoClosePrs()
 }
 
 class GitHubClientImpl(
@@ -250,6 +251,10 @@ class GitHubClientImpl(
             .also { response ->
                 response.checkNoErrors { logger.error("Error approving PR #{}", pullRequest.number) }
             }
+    }
+
+    override fun autoClosePrs() {
+        // No-op: only the stub client needs to do this
     }
 
     private suspend fun fetchRepositoryId(gitHubInfo: GitHubInfo): String {

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -266,6 +266,10 @@ class GitJaspr(
             ghClient.updatePullRequest(pr)
         }
 
+        // Call this for the benefit of the stub client in case we're running within tests. In production, this does
+        // nothing as GitHub will "auto close" PRs that are merged
+        ghClient.autoClosePrs()
+
         // Do this cleanup separately after we've rebased remaining PRs. Otherwise, if we delete a branch that's the
         // base ref for a current PR, GitHub will implicitly close it.
         logger.info("Cleaning up {} {}.", branchesToDelete.size, branchOrBranches(branchesToDelete.size))

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/OptimizedCliGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/OptimizedCliGitClient.kt
@@ -1,0 +1,36 @@
+package sims.michael.gitjaspr
+
+import java.io.File
+
+/**
+ * An optimized [GitClient] that uses [CliGitClient] for transport operations and [JGitClient] for everything else.
+ */
+class OptimizedCliGitClient private constructor(
+    private val cliGitClient: CliGitClient,
+    private val jGitClient: JGitClient,
+) : GitClient by jGitClient {
+
+    override fun clone(uri: String, bare: Boolean): GitClient {
+        cliGitClient.clone(uri, bare)
+        return this
+    }
+
+    override fun fetch(remoteName: String) {
+        cliGitClient.fetch(remoteName)
+    }
+
+    override fun push(refSpecs: List<RefSpec>) {
+        cliGitClient.push(refSpecs)
+    }
+
+    companion object {
+        operator fun invoke(
+            workingDirectory: File,
+            remoteBranchPrefix: String = RemoteRefEncoding.DEFAULT_REMOTE_BRANCH_PREFIX,
+        ): GitClient {
+            val cliGitClient = CliGitClient(workingDirectory, remoteBranchPrefix)
+            val jGitClient = JGitClient(workingDirectory, remoteBranchPrefix)
+            return OptimizedCliGitClient(cliGitClient, jGitClient)
+        }
+    }
+}

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubStubClient.kt
@@ -90,7 +90,7 @@ class GitHubStubClient(private val remoteBranchPrefix: String, private val local
 
     // Mimic GitHub's behavior since our program logic depends on it. Should be called from any method that returns
     // PRs so that the PR state is always viewed consistently with the git repo state
-    private fun autoClosePrs() {
+    override fun autoClosePrs() {
         logger.trace("autoClosePrs")
         val commitsById = localGit.logAll().associateBy(Commit::id)
         synchronized(prs) {

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
@@ -32,8 +32,8 @@ class GitHubTestHarness private constructor(
     private val useFakeRemote: Boolean = true,
 ) {
 
-    val localGit: GitClient = CliGitClient(localRepo)
-    val remoteGit: GitClient = CliGitClient(remoteRepo)
+    val localGit: GitClient = OptimizedCliGitClient(localRepo)
+    val remoteGit: GitClient = OptimizedCliGitClient(remoteRepo)
 
     private val ghClientsByUserKey: Map<String, GitHubClient> by lazy {
         if (!useFakeRemote) {


### PR DESCRIPTION
Remove --use-cli-git-client, use "optimized" git client across the board

This introduces OptimizedCliGitClient, which delegates to CliGitClient
only for transport operations, and uses JGitClient for everything else.
We're using this for everyone now and dropping --use-cli-git-client

**Stack**:
- #167 ⬅
- #166
- #165
- #164

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
