### PR TITLE
Handle error when repository ID is null

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitHubClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitHubClient.kt
@@ -259,14 +259,18 @@ class GitHubClientImpl(
 
     private suspend fun fetchRepositoryId(gitHubInfo: GitHubInfo): String {
         logger.trace("fetchRepositoryId {}", gitHubInfo)
-        val response = delegate.execute(
-            GetRepositoryId(
-                GetRepositoryId.Variables(
-                    gitHubInfo.owner,
-                    gitHubInfo.name,
+        val response = delegate
+            .execute(
+                GetRepositoryId(
+                    GetRepositoryId.Variables(
+                        gitHubInfo.owner,
+                        gitHubInfo.name,
+                    ),
                 ),
-            ),
-        )
+            )
+            .also { response ->
+                response.checkNoErrors { logger.error("Error fetching repository ID for {}", gitHubInfo) }
+            }
         val repositoryId = response.data?.repository?.id
         logger.logRateLimitInfo(response.data?.rateLimit?.toCanonicalRateLimitInfo())
         return checkNotNull(repositoryId) { "Failed to fetch repository ID, response is null" }


### PR DESCRIPTION
Handle error when repository ID is null

For https://github.com/MichaelSims/git-jaspr/issues/121

**Stack**:
- #null ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
