### PR TITLE
Render the commit subjects as an ### h3 header in PR descriptions

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CommitParsers.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CommitParsers.kt
@@ -7,6 +7,19 @@ import java.time.ZoneId
 
 object CommitParsers {
 
+    data class SubjectAndBody(val subject: String, val body: String?)
+
+    fun getSubjectAndBodyFromFullMessage(fullMessage: String): SubjectAndBody {
+        return SubjectAndBody(
+            fullMessage.substringBefore("\n\n").replace("\n", " ").trim(),
+            if (fullMessage.contains("\n\n")) {
+                fullMessage.substringAfter("\n\n").trim().takeIf(String::isNotBlank)
+            } else {
+                null
+            },
+        )
+    }
+
     fun parseCommitLogEntry(logEntry: String): Commit {
         val split = logEntry.split(GIT_FORMAT_SEPARATOR)
         check(split.size == 8) {

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -2,6 +2,7 @@ package sims.michael.gitjaspr
 
 import kotlinx.coroutines.delay
 import org.slf4j.LoggerFactory
+import sims.michael.gitjaspr.CommitParsers.getSubjectAndBodyFromFullMessage
 import sims.michael.gitjaspr.CommitParsers.trimFooters
 import sims.michael.gitjaspr.GitJaspr.StatusBits.Status
 import sims.michael.gitjaspr.GitJaspr.StatusBits.Status.*
@@ -386,7 +387,15 @@ class GitJaspr(
     ): String {
         val remoteBranches: List<String> = gitClient.getRemoteBranches().map(RemoteBranch::name)
         return buildString {
-            append(trimFooters(fullMessage))
+            val fullMessageWithoutFooters = trimFooters(fullMessage)
+            val (subject, body) = getSubjectAndBodyFromFullMessage(fullMessageWithoutFooters)
+            // Render subject with an H3 header
+            append("### ")
+            appendLine(subject)
+            if (body != null) {
+                appendLine()
+                appendLine(body)
+            }
             appendLine()
             if (pullRequests.isNotEmpty()) {
                 appendLine("**Stack**:")

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CommitParsersTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CommitParsersTest.kt
@@ -1,12 +1,62 @@
 package sims.michael.gitjaspr
 
 import org.junit.jupiter.api.Test
+import sims.michael.gitjaspr.CommitParsers.SubjectAndBody
 import sims.michael.gitjaspr.CommitParsers.addFooters
 import sims.michael.gitjaspr.CommitParsers.getFooters
+import sims.michael.gitjaspr.CommitParsers.getSubjectAndBodyFromFullMessage
 import sims.michael.gitjaspr.CommitParsers.trimFooters
 import kotlin.test.assertEquals
 
 class CommitParsersTest {
+
+    @Test
+    fun `getSubjectAndBodyFromFullMessage - subject only`() {
+        assertEquals(
+            SubjectAndBody("This is a subject", null),
+            getSubjectAndBodyFromFullMessage("This is a subject"),
+        )
+    }
+
+    @Test
+    fun `getSubjectAndBodyFromFullMessage - subject with newline`() {
+        assertEquals(
+            SubjectAndBody("This is a subject", null),
+            getSubjectAndBodyFromFullMessage("This is a subject\n"),
+        )
+    }
+
+    @Test
+    fun `getSubjectAndBodyFromFullMessage - subject and body`() {
+        val message = """
+            This is a subject
+            
+            This is a body
+            
+        """.trimIndent()
+
+        assertEquals(
+            SubjectAndBody("This is a subject", "This is a body"),
+            getSubjectAndBodyFromFullMessage(message),
+        )
+    }
+
+    @Test
+    fun `getSubjectAndBodyFromFullMessage - multiline subject`() {
+        val message = """
+            This is a subject
+            with three lines
+            but still a subject
+            
+            This is a body
+            
+        """.trimIndent()
+
+        assertEquals(
+            SubjectAndBody("This is a subject with three lines but still a subject", "This is a body"),
+            getSubjectAndBodyFromFullMessage(message),
+        )
+    }
 
     @Test
     fun `getFooters - subject only`() {

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -1500,7 +1500,7 @@ commit-id: 0
             assertEquals(
                 listOf(
                     """
-1
+### 1
 
 **Stack**:
 - %s
@@ -1509,7 +1509,7 @@ commit-id: 0
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-2
+### 2
 
 **Stack**:
 - %s
@@ -1518,7 +1518,7 @@ commit-id: 0
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-3
+### 3
 
 This is a body
 
@@ -1577,7 +1577,7 @@ This is a body
             assertEquals(
                 listOf(
                     """
-A
+### A
 
 **Stack**:
 - %s
@@ -1593,7 +1593,7 @@ A
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-B
+### B
 
 **Stack**:
 - %s
@@ -1609,7 +1609,7 @@ B
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-C
+### C
 
 **Stack**:
 - %s
@@ -1625,7 +1625,7 @@ C
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-D
+### D
 
 **Stack**:
 - %s
@@ -1636,7 +1636,7 @@ D
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-E
+### E
 
 **Stack**:
 - %s
@@ -1652,7 +1652,7 @@ E
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-one
+### one
 
 **Stack**:
 - %s
@@ -1668,7 +1668,7 @@ one
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-two
+### two
 
 **Stack**:
 - %s ⬅
@@ -1742,7 +1742,7 @@ two
             assertEquals(
                 listOf(
                     """
-A
+### A
 
 **Stack**:
 - %s
@@ -1751,7 +1751,7 @@ A
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-B
+### B
 
 **Stack**:
 - %s
@@ -1760,7 +1760,7 @@ B
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-C
+### C
 
 **Stack**:
 - %s ⬅
@@ -1769,7 +1769,7 @@ C
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-D
+### D
 
 **Stack**:
 - %s ⬅
@@ -1778,7 +1778,7 @@ D
 
                     """.trimIndent().toPrBodyString(actualIterator.next()),
                     """
-E
+### E
 
 **Stack**:
 - %s ⬅


### PR DESCRIPTION
<!-- jaspr start -->
### Render the commit subjects as an ### h3 header in PR descriptions

For https://github.com/MichaelSims/git-jaspr/issues/174

**Stack**:
- #177
  - [05..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I83070817_05..jaspr/main/I83070817), [04..05](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I83070817_04..jaspr/main/I83070817_05), [03..04](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I83070817_03..jaspr/main/I83070817_04), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I83070817_02..jaspr/main/I83070817_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I83070817_01..jaspr/main/I83070817_02)
- #176
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I4ef63479_01..jaspr/main/I4ef63479)
- #175 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
