### PR TITLE
Git push displays local stack status upon completion

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -170,6 +170,8 @@ class GitJaspr(
             ghClient.updatePullRequest(pr)
         }
         logger.info("Updated descriptions for {} pull {}", prsToMutate.size, requestOrRequests(prsToMutate.size))
+
+        print(getStatusString(refSpec))
     }
 
     suspend fun merge(refSpec: RefSpec) {


### PR DESCRIPTION
<!-- jaspr start -->
### Git push displays local stack status upon completion

**Stack**:
- #190
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I18a11789_01..jaspr/main/I18a11789)
- #189
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I1288e43f_01..jaspr/main/I1288e43f)
- #188
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I740edb6f_01..jaspr/main/I740edb6f)
- #187 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I3a9037d2_01..jaspr/main/I3a9037d2)
- #186
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic8d1db10_01..jaspr/main/Ic8d1db10)
- #192
- #191

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
