### PR TITLE
Tweak status emoji

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -641,7 +641,7 @@ class GitJaspr(
 
         @Suppress("unused")
         enum class Status(val emoji: String) {
-            SUCCESS("✅"), FAIL("❌"), PENDING("⌛"), UNKNOWN("❓"), EMPTY("➖"), WARNING("⚠️")
+            SUCCESS("✅"), FAIL("❌"), PENDING("⌛"), UNKNOWN("❓"), EMPTY("ㄧ"), WARNING("❗")
         }
     }
 

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -128,9 +128,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[➖➖➖➖➖➖] one
-                    |[➖➖➖➖➖➖] two
-                    |[➖➖➖➖➖➖] three
+                    |[ㄧㄧㄧㄧㄧㄧ] one
+                    |[ㄧㄧㄧㄧㄧㄧ] two
+                    |[ㄧㄧㄧㄧㄧㄧ] three
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -161,9 +161,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅➖➖➖➖➖] one
-                    |[➖➖➖➖➖➖] two
-                    |[➖➖➖➖➖➖] three
+                    |[✅ㄧㄧㄧㄧㄧ] one
+                    |[ㄧㄧㄧㄧㄧㄧ] two
+                    |[ㄧㄧㄧㄧㄧㄧ] three
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -199,9 +199,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅⌛✅➖➖] %s : one
-                    |[➖➖➖➖➖➖] two
-                    |[➖➖➖➖➖➖] three
+                    |[✅✅⌛✅ㄧㄧ] %s : one
+                    |[ㄧㄧㄧㄧㄧㄧ] two
+                    |[ㄧㄧㄧㄧㄧㄧ] three
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -240,9 +240,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅➖➖] %s : one
-                    |[➖➖➖➖➖➖] two
-                    |[➖➖➖➖➖➖] three
+                    |[✅✅✅✅ㄧㄧ] %s : one
+                    |[ㄧㄧㄧㄧㄧㄧ] two
+                    |[ㄧㄧㄧㄧㄧㄧ] three
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -299,8 +299,8 @@ interface GitJasprTest {
             assertEquals(
                 """
                     |[✅✅✅✅✅✅] %s : one
-                    |[✅✅✅✅➖➖] %s : two
-                    |[✅✅✅✅➖➖] %s : three
+                    |[✅✅✅✅ㄧㄧ] %s : two
+                    |[✅✅✅✅ㄧㄧ] %s : three
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -367,9 +367,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅✅➖] %s : one
-                    |[✅✅✅✅✅➖] %s : two
-                    |[✅✅✅✅✅➖] %s : three
+                    |[✅✅✅✅✅ㄧ] %s : one
+                    |[✅✅✅✅✅ㄧ] %s : two
+                    |[✅✅✅✅✅ㄧ] %s : three
                     |
                     |Your stack is out-of-date with the base branch (1 commit behind main).
                     |You'll need to rebase it (`git rebase origin/main`) before your stack will be mergeable.
@@ -442,9 +442,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅✅➖] %s : one
-                    |[✅✅✅✅✅➖] %s : two
-                    |[✅✅✅✅✅➖] %s : three
+                    |[✅✅✅✅✅ㄧ] %s : one
+                    |[✅✅✅✅✅ㄧ] %s : two
+                    |[✅✅✅✅✅ㄧ] %s : three
                     |
                     |Your stack is out-of-date with the base branch (2 commits behind main).
                     |You'll need to rebase it (`git rebase origin/main`) before your stack will be mergeable.
@@ -570,7 +570,7 @@ interface GitJasprTest {
                 """
                     |[✅✅✅✅✅✅] %s : one
                     |[✅✅✅✅✅✅] %s : two
-                    |[✅✅✅➖✅➖] %s : draft: three
+                    |[✅✅✅ㄧ✅ㄧ] %s : draft: three
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -628,9 +628,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEventuallyEquals(
                 """
-                    |[✅✅✅✅➖➖] %s : one
-                    |[✅✅✅✅✅➖] %s : two
-                    |[✅✅✅✅➖➖] %s : three
+                    |[✅✅✅✅ㄧㄧ] %s : one
+                    |[✅✅✅✅✅ㄧ] %s : two
+                    |[✅✅✅✅ㄧㄧ] %s : three
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -687,9 +687,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅➖➖] %s : one
-                    |[✅✅❌✅➖➖] %s : two
-                    |[✅✅✅✅➖➖] %s : three
+                    |[✅✅✅✅ㄧㄧ] %s : one
+                    |[✅✅❌✅ㄧㄧ] %s : two
+                    |[✅✅✅✅ㄧㄧ] %s : three
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -822,8 +822,8 @@ interface GitJasprTest {
             assertEquals(
                 """
                     |[✅✅✅✅✅✅] %s : one
-                    |[⚠️✅✅✅✅➖] %s : three
-                    |[⚠️✅✅✅✅➖] %s : four
+                    |[❗✅✅✅✅ㄧ] %s : three
+                    |[❗✅✅✅✅ㄧ] %s : four
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -858,9 +858,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[⚠️➖➖➖➖➖] one
-                    |[⚠️➖➖➖➖➖] two
-                    |[➖➖➖➖➖➖] three
+                    |[❗ㄧㄧㄧㄧㄧ] one
+                    |[❗ㄧㄧㄧㄧㄧ] two
+                    |[ㄧㄧㄧㄧㄧㄧ] three
                     |
                     |Some commits in your local stack have duplicate IDs:
                     |- a: (one, two)


### PR DESCRIPTION
<!-- jaspr start -->
### Tweak status emoji

- Replace "Heavy Minus Sign" (\u2796) for "empty" with
  "Bopomofo Letter I" (\u3127) because the latter renders as a white
  dash in my terminal and shows up much better than the former
- Replace "Warning Sign" (\u26a0\ufe0f) with
  "Heavy Exclamation Mark Symbol" (\u2757). The former relies on a
  second unicode code point known as the "variation selector" to render
  as an image instead of text, and this is apparently not supported by
  my terminal very well. (It shows up, but is half-width and looks bad.)
  The latter is a single code point and renders properly

**Stack**:
- #190
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I18a11789_01..jaspr/main/I18a11789)
- #189
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I1288e43f_01..jaspr/main/I1288e43f)
- #188 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I740edb6f_01..jaspr/main/I740edb6f)
- #187
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I3a9037d2_01..jaspr/main/I3a9037d2)
- #186
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic8d1db10_01..jaspr/main/Ic8d1db10)
- #192
- #191

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
