### PR TITLE
Status format overhaul

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -31,7 +31,23 @@ import sims.michael.gitjaspr.RemoteRefEncoding.DEFAULT_REMOTE_BRANCH_PREFIX
 import java.io.File
 
 //region Commands
-class Status : GitJasprCommand(help = "Show status of current stack") {
+class Status : GitJasprCommand(
+    help =
+    // language=Markdown
+    """
+Show status of current stack
+ 
+| Heading       | Description                                                                                                                                                                                                                           |
+|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| commit pushed | The commit has been pushed to the remote.                                                                                                                                                                                             |
+| exists        | A pull request has been created for the given commit.                                                                                                                                                                                 |
+| checks pass   | Github checks pass.                                                                                                                                                                                                                   |
+| ready         | The PR is ready for review, which means it is not a draft. Commits with subjects that begin with `DRAFT` or `WIP` will automatically be created in draft mode. Use the GitHub UI to mark the PR as ready for review when appropriate. |
+| approved      | The PR is approved.                                                                                                                                                                                                                   |
+| stack check   | This commit is mergeable, as well as all of its parent commits in the stack.                                                                                                                                                          |
+
+    """.trimIndent(),
+) {
     private val refSpec by argument()
         .convert(conversion = ArgumentTransformContext::convertRefSpecString)
         .help {

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -652,12 +652,12 @@ class GitJaspr(
 
     companion object {
         private val HEADER = """
-            | ┌─ commit is pushed
-            | │ ┌─ pull request exists
-            | │ │ ┌─ github checks pass
-            | │ │ │ ┌─ pull request is not a draft
-            | │ │ │ │ ┌── pull request approved
-            | │ │ │ │ │ ┌─── stack check
+            | ┌─────────── commit pushed
+            | │ ┌─────────── exists       ┐
+            | │ │ ┌───────── checks pass  │ PR
+            | │ │ │ ┌─────── ready        │
+            | │ │ │ │ ┌───── approved     ┘
+            | │ │ │ │ │ ┌─ stack check
             | │ │ │ │ │ │ 
 
         """.trimMargin()

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -2776,12 +2776,12 @@ This is a body
             this
         }
         return """
-            | ┌─ commit is pushed
-            | │ ┌─ pull request exists
-            | │ │ ┌─ github checks pass
-            | │ │ │ ┌─ pull request is not a draft
-            | │ │ │ │ ┌── pull request approved
-            | │ │ │ │ │ ┌─── stack check
+            | ┌─────────── commit pushed
+            | │ ┌─────────── exists       ┐
+            | │ │ ┌───────── checks pass  │ PR
+            | │ │ │ ┌─────── ready        │
+            | │ │ │ │ ┌───── approved     ┘
+            | │ │ │ │ │ ┌─ stack check
             | │ │ │ │ │ │ 
             |$formattedString
 


### PR DESCRIPTION
<!-- jaspr start -->
### Status format overhaul

- Group and indent PR-related bits
- Tweak and simplify heading language
- Include a table in the status help output that details the headings

**Stack**:
- #190
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I18a11789_01..jaspr/main/I18a11789)
- #189 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I1288e43f_01..jaspr/main/I1288e43f)
- #188
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I740edb6f_01..jaspr/main/I740edb6f)
- #187
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I3a9037d2_01..jaspr/main/I3a9037d2)
- #186
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic8d1db10_01..jaspr/main/Ic8d1db10)
- #192
- #191

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
