### PR TITLE
Bump gradle/gradle-build-action from 2.11.0 to 2.11.1

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -63,7 +63,7 @@ jobs:
           java-version: "11.0.21-zulu"
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@8cbcb9948b5892387aed077daf6f90e1f0ba5b27 # v2.11.0
+        uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2.11.1
 
       - name: Run Tests
         run: ./gradlew build --configure-on-demand --max-workers=4


### PR DESCRIPTION
<!-- jaspr start -->
### Bump gradle/gradle-build-action from 2.11.0 to 2.11.1

Bumps [gradle/gradle-build-action](https://github.com/gradle/gradle-build-action) from 2.11.0 to 2.11.1.
- [Release notes](https://github.com/gradle/gradle-build-action/releases)
- [Commits](https://github.com/gradle/gradle-build-action/compare/8cbcb9948b5892387aed077daf6f90e1f0ba5b27...982da8e78c05368c70dac0351bb82647a9e9a5d2)

commit-id: I7011736e

---
updated-dependencies:
- dependency-name: gradle/gradle-build-action
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

**Stack**:
- #190
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I18a11789_01..jaspr/main/I18a11789)
- #189
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I1288e43f_01..jaspr/main/I1288e43f)
- #188
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I740edb6f_01..jaspr/main/I740edb6f)
- #187
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I3a9037d2_01..jaspr/main/I3a9037d2)
- #186
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic8d1db10_01..jaspr/main/Ic8d1db10)
- #192
- #191 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
