### PR TITLE
Bump EnricoMi/publish-unit-test-result-action from 2.11.0 to 2.12.0

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@ca89ad036b5fcd524c1017287fb01b5139908408  # v2.11.0
+        uses: EnricoMi/publish-unit-test-result-action@e780361cd1fc1b1a170624547b3ffda64787d365  # v2.12.0
         if: always()
         with:
           junit_files: "**/build/test-results/**/*.xml"


### PR DESCRIPTION
<!-- jaspr start -->
### Bump EnricoMi/publish-unit-test-result-action from 2.11.0 to 2.12.0

Bumps [EnricoMi/publish-unit-test-result-action](https://github.com/enricomi/publish-unit-test-result-action) from 2.11.0 to 2.12.0.
- [Release notes](https://github.com/enricomi/publish-unit-test-result-action/releases)
- [Commits](https://github.com/enricomi/publish-unit-test-result-action/compare/ca89ad036b5fcd524c1017287fb01b5139908408...e780361cd1fc1b1a170624547b3ffda64787d365)

commit-id: I54eb979f

---
updated-dependencies:
- dependency-name: EnricoMi/publish-unit-test-result-action
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

**Stack**:
- #190
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I18a11789_01..jaspr/main/I18a11789)
- #189
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I1288e43f_01..jaspr/main/I1288e43f)
- #188
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I740edb6f_01..jaspr/main/I740edb6f)
- #187
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I3a9037d2_01..jaspr/main/I3a9037d2)
- #186
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic8d1db10_01..jaspr/main/Ic8d1db10)
- #192 ⬅
- #191

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
