### PR TITLE
Add autoMerge with limited refSpec test

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -2024,6 +2024,83 @@ This is a body
     }
 
     @Test
+    fun `autoMerge with limited refSpec`() {
+        withTestSetup(useFakeRemote) {
+            createCommitsFrom(
+                testCase {
+                    repository {
+                        commit {
+                            title = "one"
+                            willPassVerification = true
+                            remoteRefs += buildRemoteRef("one")
+                        }
+                        commit {
+                            title = "two"
+                            willPassVerification = true
+                            remoteRefs += buildRemoteRef("two")
+                        }
+                        commit {
+                            title = "three"
+                            willPassVerification = true
+                            remoteRefs += buildRemoteRef("three")
+                        }
+                        commit {
+                            title = "four"
+                            willPassVerification = true
+                            remoteRefs += buildRemoteRef("four")
+                        }
+                        commit {
+                            title = "five"
+                            willPassVerification = true
+                            remoteRefs += buildRemoteRef("five")
+                            localRefs += "development"
+                        }
+                    }
+                    pullRequest {
+                        headRef = buildRemoteRef("one")
+                        baseRef = "main"
+                        title = "one"
+                        willBeApprovedByUserKey = "michael"
+                    }
+                    pullRequest {
+                        headRef = buildRemoteRef("two")
+                        baseRef = buildRemoteRef("one")
+                        title = "two"
+                        willBeApprovedByUserKey = "michael"
+                    }
+                    pullRequest {
+                        headRef = buildRemoteRef("three")
+                        baseRef = buildRemoteRef("two")
+                        title = "three"
+                        willBeApprovedByUserKey = "michael"
+                    }
+                    pullRequest {
+                        headRef = buildRemoteRef("four")
+                        baseRef = buildRemoteRef("three")
+                        title = "four"
+                        willBeApprovedByUserKey = "michael"
+                    }
+                    pullRequest {
+                        headRef = buildRemoteRef("five")
+                        baseRef = buildRemoteRef("four")
+                        title = "five"
+                        willBeApprovedByUserKey = "michael"
+                    }
+                },
+            )
+
+            autoMerge(RefSpec("development^", "main"))
+
+            assertEquals(
+                listOf("five"),
+                localGit
+                    .getLocalCommitStack(DEFAULT_REMOTE_NAME, "development", DEFAULT_TARGET_REF)
+                    .map(Commit::shortMessage),
+            )
+        }
+    }
+
+    @Test
     fun `merge fails when behind target branch`() {
         withTestSetup(useFakeRemote) {
             createCommitsFrom(


### PR DESCRIPTION
<!-- jaspr start -->
### Add autoMerge with limited refSpec test

This is for https://github.com/MichaelSims/git-jaspr/issues/195
but since this passes with no code changes, that bug is looking like
either a bug in Ktor/Graphql (probably not) or a transient connection
issue with GitHub

**Stack**:
- #211
- #210
- #209
- #208
- #207
- #205
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia419d0c1_01..jaspr/main/Ia419d0c1)
- #204
- #203
- #202
- #201
- #200
- #199
- #198 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
