### PR TITLE
Upgrade GraphQL and Ktor dependencies

### DIFF
--- a/git-jaspr/src/main/resources/META-INF/native-image/reflect-config.json
+++ b/git-jaspr/src/main/resources/META-INF/native-image/reflect-config.json
@@ -502,7 +502,7 @@
 },
 {
   "name":"kotlinx.coroutines.CancellableContinuationImpl",
-  "fields":[{"name":"_decision"}, {"name":"_state"}]
+  "fields":[{"name":"_decision"}, {"name":"_decisionAndIndex"}, {"name":"_parentHandle"}, {"name":"_state"}]
 },
 {
   "name":"kotlinx.coroutines.CancelledContinuation",
@@ -514,7 +514,7 @@
 },
 {
   "name":"kotlinx.coroutines.EventLoopImplBase",
-  "fields":[{"name":"_delayed"}, {"name":"_queue"}]
+  "fields":[{"name":"_delayed"}, {"name":"_isCompleted"}, {"name":"_queue"}]
 },
 {
   "name":"kotlinx.coroutines.InvokeOnCancelling",
@@ -522,11 +522,19 @@
 },
 {
   "name":"kotlinx.coroutines.JobSupport",
-  "fields":[{"name":"_state"}]
+  "fields":[{"name":"_parentHandle"}, {"name":"_state"}]
+},
+{
+  "name":"kotlinx.coroutines.JobSupport$Finishing",
+  "fields":[{"name":"_exceptionsHolder"}, {"name":"_isCompleting"}, {"name":"_rootCause"}]
 },
 {
   "name":"kotlinx.coroutines.channels.AbstractSendChannel",
   "fields":[{"name":"onCloseHandler"}]
+},
+{
+  "name":"kotlinx.coroutines.channels.BufferedChannel",
+  "fields":[{"name":"_closeCause"}, {"name":"bufferEnd"}, {"name":"bufferEndSegment"}, {"name":"closeHandler"}, {"name":"completedExpandBuffersAndPauseFlag"}, {"name":"receiveSegment"}, {"name":"receivers"}, {"name":"sendSegment"}, {"name":"sendersAndCloseStatus"}]
 },
 {
   "name":"kotlinx.coroutines.internal.AtomicOp",
@@ -539,6 +547,10 @@
 {
   "name":"kotlinx.coroutines.internal.DispatchedContinuation",
   "fields":[{"name":"_reusableCancellableContinuation"}]
+},
+{
+  "name":"kotlinx.coroutines.internal.LimitedDispatcher",
+  "fields":[{"name":"runningWorkers"}]
 },
 {
   "name":"kotlinx.coroutines.internal.LockFreeLinkedListNode",
@@ -555,6 +567,10 @@
 {
   "name":"kotlinx.coroutines.internal.Segment",
   "fields":[{"name":"cleanedAndPointers"}]
+},
+{
+  "name":"kotlinx.coroutines.internal.ThreadSafeHeap",
+  "fields":[{"name":"_size"}]
 },
 {
   "name":"kotlinx.coroutines.scheduling.CoroutineScheduler",

--- a/libs.versions.toml
+++ b/libs.versions.toml
@@ -7,14 +7,14 @@ jgit = "6.7.0.202309050840-r"
 kotlin = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-graphql = { id = "com.expediagroup.graphql", version = "6.4.1" }
+graphql = { id = "com.expediagroup.graphql", version = "6.5.7" }
 spotless = { id = "com.diffplug.spotless", version = "6.21.0" }
 graalvm = { id = "org.graalvm.buildtools.native", version = "0.9.12" }
 
 [libraries]
 auto-service = { module = "com.google.auto.service:auto-service", version = "1.0.1" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version = "4.2.0" }
-graphql-kotlin-ktor-client = { module = "com.expediagroup:graphql-kotlin-ktor-client", version = "6.4.1" }
+graphql-kotlin-ktor-client = { module = "com.expediagroup:graphql-kotlin-ktor-client", version = "6.5.7" }
 jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
 jgit-junit = { module = "org.eclipse.jgit:org.eclipse.jgit.junit", version.ref = "jgit" }
 jgit-ssh = { module = "org.eclipse.jgit:org.eclipse.jgit.ssh.jsch", version.ref = "jgit" }
@@ -23,7 +23,7 @@ kotlin-test-junit5 = { module = "org.jetbrains.kotlin:kotlin-test-junit5", versi
 kotlinpoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinpoet" }
 kotlinpoet-metadata = { module = "com.squareup:kotlinpoet-metadata", version.ref = "kotlinpoet" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version = "1.5.1" }
-ktor-client-auth = { module = "io.ktor:ktor-client-auth", version = "2.3.0" }
+ktor-client-auth = { module = "io.ktor:ktor-client-auth", version = "2.3.7" }
 logback-classic = { module = "ch.qos.logback:logback-classic", version = "1.4.6" }
 mockito-inline = { module = "org.mockito:mockito-inline", version = "2.23.0" }
 mockito-kotlin = { module = "com.nhaarman.mockitokotlin2:mockito-kotlin", version = "2.2.0" }


### PR DESCRIPTION
<!-- jaspr start -->
### Upgrade GraphQL and Ktor dependencies

This is to attempt to mitigate
https://github.com/MichaelSims/git-jaspr/issues/195

Note that the native-image metadata is also updated

**Stack**:
- #211
- #210
- #209
- #208
- #207
- #205
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia419d0c1_01..jaspr/main/Ia419d0c1)
- #204
- #203
- #202
- #201
- #200
- #199 ⬅
- #198

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
