### PR TITLE
Update `status with out of date commit` test to wait for status checks

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -818,6 +818,8 @@ interface GitJasprTest {
                 },
             )
 
+            waitForChecksToConclude("one", "three", "four")
+
             val actual = getAndPrintStatusString(RefSpec("development", "main"))
             assertEquals(
                 """


### PR DESCRIPTION
<!-- jaspr start -->
### Update `status with out of date commit` test to wait for status checks

This fails in the functional tests without this

**Stack**:
- #211
- #210
- #209
- #208
- #207
- #205
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia419d0c1_01..jaspr/main/Ia419d0c1)
- #204
- #203
- #202 ⬅
- #201
- #200
- #199
- #198

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
