### PR TITLE
getRemoteBranches should filter by remote name

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
@@ -19,8 +19,8 @@ interface GitClient {
     fun getLocalCommitStack(remoteName: String, localObjectName: String, targetRefName: String): List<Commit>
     fun refExists(ref: String): Boolean
     fun getBranchNames(): List<String>
-    fun getRemoteBranches(): List<RemoteBranch>
-    fun getRemoteBranchesById(): Map<String, RemoteBranch>
+    fun getRemoteBranches(remoteName: String = DEFAULT_REMOTE_NAME): List<RemoteBranch>
+    fun getRemoteBranchesById(remoteName: String = DEFAULT_REMOTE_NAME): Map<String, RemoteBranch>
     fun reset(refName: String): GitClient
     fun branch(name: String, startPoint: String = "HEAD", force: Boolean = false): Commit?
     fun deleteBranches(names: List<String>, force: Boolean = false): List<String>

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -105,7 +105,7 @@ class GitJaspr(
         val pullRequests = checkSinglePullRequestPerCommit(ghClient.getPullRequests(stack))
         val pullRequestsRebased = pullRequests.updateBaseRefForReorderedPrsIfAny(stack, refSpec.remoteRef)
 
-        val remoteBranches = gitClient.getRemoteBranches()
+        val remoteBranches = gitClient.getRemoteBranches(config.remoteName)
         val outOfDateBranches = stack.map { c -> c.toRefSpec() } - remoteBranches.map { b -> b.toRefSpec() }.toSet()
         val revisionHistoryRefs = getRevisionHistoryRefs(
             stack,
@@ -305,7 +305,7 @@ class GitJaspr(
         val pullRequests = ghClient.getPullRequests().map(PullRequest::headRefName).toSet()
         gitClient.fetch(config.remoteName)
         val orphanedBranches = gitClient
-            .getRemoteBranches()
+            .getRemoteBranches(config.remoteName)
             .map(RemoteBranch::name)
             .filter {
                 val remoteRefParts = getRemoteRefParts(it, config.remoteBranchPrefix)
@@ -388,7 +388,7 @@ class GitJaspr(
         pullRequests: List<PullRequest> = emptyList(),
         existingPr: PullRequest? = null,
     ): String {
-        val remoteBranches: List<String> = gitClient.getRemoteBranches().map(RemoteBranch::name)
+        val remoteBranches: List<String> = gitClient.getRemoteBranches(config.remoteName).map(RemoteBranch::name)
         val jasprStartComment = "<!-- jaspr start -->"
         return buildString {
             if (existingPr != null && existingPr.body.contains(jasprStartComment)) {
@@ -486,7 +486,7 @@ class GitJaspr(
         logger.trace("Deletion candidates {}", deletionCandidates)
 
         val branchesToDelete = gitClient
-            .getRemoteBranches()
+            .getRemoteBranches(config.remoteName)
             .map(RemoteBranch::name)
             .filter { branchName ->
                 getRemoteRefParts(branchName, config.remoteBranchPrefix)


### PR DESCRIPTION
<!-- jaspr start -->
### getRemoteBranches should filter by remote name

**Stack**:
- #211
- #210
- #209
- #208
- #207
- #205 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia419d0c1_01..jaspr/main/Ia419d0c1)
- #204
- #203
- #202
- #201
- #200
- #199
- #198

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
