### PR TITLE
Bugfix: make non-default remote names actually work

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Git.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Git.kt
@@ -28,5 +28,5 @@ fun generateUuid(length: Int = 8): String {
 }
 
 fun refsHeads(branch: String) = if (!branch.startsWith(GitClient.R_HEADS)) "${GitClient.R_HEADS}$branch" else branch
-fun refsRemotes(branch: String, remote: String = DEFAULT_REMOTE_NAME) =
+fun refsRemotes(branch: String, remote: String) =
     if (!branch.startsWith(GitClient.R_REMOTES)) "${GitClient.R_REMOTES}$remote/$branch" else branch

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
@@ -8,7 +8,7 @@ interface GitClient {
     val remoteBranchPrefix: String
     fun init(): GitClient
     fun checkout(refName: String): GitClient
-    fun clone(uri: String, bare: Boolean = false): GitClient
+    fun clone(uri: String, remoteName: String = DEFAULT_REMOTE_NAME, bare: Boolean = false): GitClient
     fun fetch(remoteName: String)
     fun log(): List<Commit>
     fun log(revision: String, maxCount: Int = -1): List<Commit>
@@ -28,9 +28,7 @@ interface GitClient {
     fun setCommitId(commitId: String, commitIdent: Ident? = null)
     fun commit(message: String, footerLines: Map<String, String> = emptyMap(), commitIdent: Ident? = null): Commit
     fun cherryPick(commit: Commit, commitIdent: Ident? = null): Commit
-
-    // TODO this should accept the remote to push to!
-    fun push(refSpecs: List<RefSpec>)
+    fun push(refSpecs: List<RefSpec>, remoteName: String = DEFAULT_REMOTE_NAME)
     fun getRemoteUriOrNull(remoteName: String): String?
 
     companion object {

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
@@ -48,10 +48,16 @@ class JGitClient(
         }
     }
 
-    override fun clone(uri: String, bare: Boolean): GitClient {
+    override fun clone(uri: String, remoteName: String, bare: Boolean): GitClient {
         logger.trace("clone {}", uri)
         return apply {
-            Git.cloneRepository().setDirectory(workingDirectory).setURI(uri).setBare(bare).call().close()
+            Git.cloneRepository()
+                .setDirectory(workingDirectory)
+                .setURI(uri)
+                .setBare(bare)
+                .setRemote(remoteName)
+                .call()
+                .close()
         }
     }
 
@@ -245,7 +251,7 @@ class JGitClient(
         }
     }
 
-    override fun push(refSpecs: List<RefSpec>) {
+    override fun push(refSpecs: List<RefSpec>, remoteName: String) {
         logger.trace("push {}", refSpecs)
         if (refSpecs.isNotEmpty()) {
             useGit { git ->
@@ -255,6 +261,7 @@ class JGitClient(
                 checkNoPushErrors(
                     git
                         .push()
+                        .setRemote(remoteName)
                         .setAtomic(true)
                         .setRefSpecs(specs)
                         .call(),

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/OptimizedCliGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/OptimizedCliGitClient.kt
@@ -10,8 +10,8 @@ class OptimizedCliGitClient private constructor(
     private val jGitClient: JGitClient,
 ) : GitClient by jGitClient {
 
-    override fun clone(uri: String, bare: Boolean): GitClient {
-        cliGitClient.clone(uri, bare)
+    override fun clone(uri: String, remoteName: String, bare: Boolean): GitClient {
+        cliGitClient.clone(uri, remoteName, bare)
         return this
     }
 
@@ -19,8 +19,8 @@ class OptimizedCliGitClient private constructor(
         cliGitClient.fetch(remoteName)
     }
 
-    override fun push(refSpecs: List<RefSpec>) {
-        cliGitClient.push(refSpecs)
+    override fun push(refSpecs: List<RefSpec>, remoteName: String) {
+        cliGitClient.push(refSpecs, remoteName)
     }
 
     companion object {

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliGitClientTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliGitClientTest.kt
@@ -286,8 +286,8 @@ class CliGitClientTest {
             val cliGit = CliGitClient(localGit.workingDirectory)
             val git = JGitClient(localGit.workingDirectory)
             assertEquals(
-                cliGit.getLocalCommitStack(DEFAULT_REMOTE_NAME, DEFAULT_TARGET_REF, DEFAULT_TARGET_REF),
-                git.getLocalCommitStack(DEFAULT_REMOTE_NAME, DEFAULT_TARGET_REF, DEFAULT_TARGET_REF),
+                cliGit.getLocalCommitStack(remoteName, DEFAULT_TARGET_REF, DEFAULT_TARGET_REF),
+                git.getLocalCommitStack(remoteName, DEFAULT_TARGET_REF, DEFAULT_TARGET_REF),
             )
         }
     }
@@ -455,8 +455,8 @@ class CliGitClientTest {
             val cliGit = CliGitClient(localGit.workingDirectory)
             val git = JGitClient(localGit.workingDirectory)
             assertEquals(
-                cliGit.getRemoteUriOrNull(DEFAULT_REMOTE_NAME),
-                git.getRemoteUriOrNull(DEFAULT_REMOTE_NAME),
+                cliGit.getRemoteUriOrNull(remoteName),
+                git.getRemoteUriOrNull(remoteName),
             )
         }
     }
@@ -645,7 +645,7 @@ This is a commit body
                 },
             )
             val git = CliGitClient(localGit.workingDirectory)
-            git.push(listOf(RefSpec("development", "main")))
+            git.push(listOf(RefSpec("development", "main")), remoteName)
             assertEquals("one", remoteGit.log("main", 1).single().shortMessage)
         }
     }

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalExternalProcessTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalExternalProcessTest.kt
@@ -42,11 +42,11 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
         executeCli(
             scratchDir = scratchDir,
             remoteUri = remoteUri,
-            remoteName = DEFAULT_REMOTE_NAME,
+            remoteName = remoteName,
             extraCliArgs = emptyList(),
             homeDirConfig = buildHomeDirConfig(),
             repoDirConfig = emptyMap(),
-            strings = listOf("push"),
+            strings = listOf("push", remoteName),
             invokeLocation = localRepo,
             javaOptions = javaOptions,
         ).lines().drop(1).joinToString("\n") // Hacky, drop the first line which is debug output.
@@ -56,11 +56,11 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
         return executeCli(
             scratchDir = scratchDir,
             remoteUri = remoteUri,
-            remoteName = DEFAULT_REMOTE_NAME,
+            remoteName = remoteName,
             extraCliArgs = emptyList(),
             homeDirConfig = buildHomeDirConfig(),
             repoDirConfig = emptyMap(),
-            strings = listOf("status", DEFAULT_REMOTE_NAME, refSpec.toString()),
+            strings = listOf("status", remoteName, refSpec.toString()),
             invokeLocation = localRepo,
             javaOptions = javaOptions,
 
@@ -71,11 +71,11 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
         executeCli(
             scratchDir = scratchDir,
             remoteUri = remoteUri,
-            remoteName = DEFAULT_REMOTE_NAME,
+            remoteName = remoteName,
             extraCliArgs = emptyList(),
             homeDirConfig = buildHomeDirConfig(),
             repoDirConfig = emptyMap(),
-            strings = listOf("merge", DEFAULT_REMOTE_NAME, refSpec.toString()),
+            strings = listOf("merge", remoteName, refSpec.toString()),
             invokeLocation = localRepo,
             javaOptions = javaOptions,
         )
@@ -85,13 +85,13 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
         executeCli(
             scratchDir = scratchDir,
             remoteUri = remoteUri,
-            remoteName = DEFAULT_REMOTE_NAME,
+            remoteName = remoteName,
             extraCliArgs = emptyList(),
             homeDirConfig = buildHomeDirConfig(),
             repoDirConfig = emptyMap(),
             strings = listOf(
                 "auto-merge",
-                DEFAULT_REMOTE_NAME,
+                remoteName,
                 refSpec.toString(),
                 "--interval",
                 pollingIntervalSeconds.toString(),

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -80,8 +80,8 @@ interface GitJasprTest {
                 },
             )
             push()
-            localGit.fetch(DEFAULT_REMOTE_NAME)
-            val stack = localGit.getLocalCommitStack(DEFAULT_REMOTE_NAME, DEFAULT_LOCAL_OBJECT, DEFAULT_TARGET_REF)
+            localGit.fetch(remoteName)
+            val stack = localGit.getLocalCommitStack(remoteName, DEFAULT_LOCAL_OBJECT, DEFAULT_TARGET_REF)
             val remoteCommitStatuses = getRemoteCommitStatuses(stack)
             assertEquals(localGit.log("HEAD", maxCount = 1).single(), remoteCommitStatuses.single().remoteCommit)
         }
@@ -372,7 +372,7 @@ interface GitJasprTest {
                     |[✅✅✅✅✅ㄧ] %s : %s : three
                     |
                     |Your stack is out-of-date with the base branch (1 commit behind main).
-                    |You'll need to rebase it (`git rebase origin/main`) before your stack will be mergeable.
+                    |You'll need to rebase it (`git rebase $remoteName/main`) before your stack will be mergeable.
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -447,7 +447,7 @@ interface GitJasprTest {
                     |[✅✅✅✅✅ㄧ] %s : %s : three
                     |
                     |Your stack is out-of-date with the base branch (2 commits behind main).
-                    |You'll need to rebase it (`git rebase origin/main`) before your stack will be mergeable.
+                    |You'll need to rebase it (`git rebase $remoteName/main`) before your stack will be mergeable.
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -929,7 +929,7 @@ interface GitJasprTest {
 
             assertEquals(
                 listOf("three", "two", "one"),
-                localGit.log("origin/main", maxCount = 3).map(Commit::shortMessage),
+                localGit.log("$remoteName/main", maxCount = 3).map(Commit::shortMessage),
             )
         }
     }
@@ -1155,7 +1155,7 @@ commit-id: 0
 
             assertEquals(
                 (1..3).map { buildRemoteRef(it.toString()) },
-                localGit.getRemoteBranches().map(RemoteBranch::name) - DEFAULT_TARGET_REF,
+                localGit.getRemoteBranches(remoteName).map(RemoteBranch::name) - DEFAULT_TARGET_REF,
             )
         }
     }
@@ -1210,7 +1210,7 @@ commit-id: 0
                 listOf("a", "a_01", "b", "b_01", "c", "c_01", "d", "e", "z")
                     .map { name -> buildRemoteRef(name) },
                 localGit
-                    .getRemoteBranches()
+                    .getRemoteBranches(remoteName)
                     .map(RemoteBranch::name)
                     .filter { name -> name.startsWith(RemoteRefEncoding.DEFAULT_REMOTE_BRANCH_PREFIX) }
                     .sorted(),
@@ -1867,7 +1867,7 @@ This is a body
 
             assertEquals(
                 emptyList(),
-                localGit.getLocalCommitStack(DEFAULT_REMOTE_NAME, "development", DEFAULT_TARGET_REF),
+                localGit.getLocalCommitStack(remoteName, "development", DEFAULT_TARGET_REF),
             )
         }
     }
@@ -1935,7 +1935,7 @@ This is a body
 
             assertEquals(
                 emptyList(),
-                localGit.getLocalCommitStack(DEFAULT_REMOTE_NAME, "main", DEFAULT_TARGET_REF),
+                localGit.getLocalCommitStack(remoteName, "main", DEFAULT_TARGET_REF),
             )
         }
     }
@@ -1967,7 +1967,7 @@ This is a body
 
             assertEquals(
                 emptyList(),
-                localGit.getLocalCommitStack(DEFAULT_REMOTE_NAME, "development", DEFAULT_TARGET_REF),
+                localGit.getLocalCommitStack(remoteName, "development", DEFAULT_TARGET_REF),
             )
         }
     }
@@ -2020,7 +2020,7 @@ This is a body
 
             assertEquals(
                 emptyList(),
-                localGit.getLocalCommitStack(DEFAULT_REMOTE_NAME, "development", DEFAULT_TARGET_REF),
+                localGit.getLocalCommitStack(remoteName, "development", DEFAULT_TARGET_REF),
             )
         }
     }
@@ -2096,7 +2096,7 @@ This is a body
             assertEquals(
                 listOf("five"),
                 localGit
-                    .getLocalCommitStack(DEFAULT_REMOTE_NAME, "development", DEFAULT_TARGET_REF)
+                    .getLocalCommitStack(remoteName, "development", DEFAULT_TARGET_REF)
                     .map(Commit::shortMessage),
             )
         }
@@ -2162,7 +2162,7 @@ This is a body
             assertEquals(
                 listOf("one", "two", "three"), // Nothing was merged
                 localGit
-                    .getLocalCommitStack(DEFAULT_REMOTE_NAME, "development", DEFAULT_TARGET_REF)
+                    .getLocalCommitStack(remoteName, "development", DEFAULT_TARGET_REF)
                     .map(Commit::shortMessage),
             )
         }
@@ -2240,7 +2240,7 @@ This is a body
                 // All mergeable commits were merged, leaving c, d, and e as the only one not merged
                 listOf("draft: c", "d", "e"),
                 localGit
-                    .getLocalCommitStack(DEFAULT_REMOTE_NAME, "development", DEFAULT_TARGET_REF)
+                    .getLocalCommitStack(remoteName, "development", DEFAULT_TARGET_REF)
                     .map(Commit::shortMessage),
             )
         }
@@ -2583,7 +2583,7 @@ This is a body
                     buildRemoteRef("c_01"),
                     "main",
                 ),
-                localGit.getRemoteBranches().map(RemoteBranch::name),
+                localGit.getRemoteBranches(remoteName).map(RemoteBranch::name),
             )
         }
     }
@@ -2755,7 +2755,7 @@ This is a body
                 // One was merged, leaving three and four unmerged
                 listOf("three", "four"),
                 localGit
-                    .getLocalCommitStack(DEFAULT_REMOTE_NAME, "development", DEFAULT_TARGET_REF)
+                    .getLocalCommitStack(remoteName, "development", DEFAULT_TARGET_REF)
                     .map(Commit::shortMessage),
             )
         }
@@ -2835,7 +2835,7 @@ This is a body
                     buildRemoteRef("z"),
                     "main",
                 ),
-                localGit.getRemoteBranches().map(RemoteBranch::name),
+                localGit.getRemoteBranches(remoteName).map(RemoteBranch::name),
             )
         }
     }

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarnessTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarnessTest.kt
@@ -143,7 +143,7 @@ class GitHubTestHarnessTest {
                 assertEquals(commitOneTwo.copy(shortMessage = "commit_one_one"), commitOneTwo)
             }
 
-            localGit.logRange("$DEFAULT_REMOTE_NAME/one~2", "$DEFAULT_REMOTE_NAME/one").let { log ->
+            localGit.logRange("$remoteName/one~2", "$remoteName/one").let { log ->
                 assertEquals(2, log.size)
                 val (commitOneOne, commitOneTwo) = log
                 assertEquals(commitOneOne.copy(shortMessage = "commit_one_one"), commitOneOne)


### PR DESCRIPTION
<!-- jaspr start -->
### Bugfix: make non-default remote names actually work

There were tons of places where the remote name was not parameterized
and assumed to just be "origin". Using Jaspr with some other remote name
clearly would not have worked. This commit should fix that.

**Stack**:
- #211
- #210
- #209
- #208
- #207 ⬅
- #205
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia419d0c1_01..jaspr/main/Ia419d0c1)
- #204
- #203
- #202
- #201
- #200
- #199
- #198

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
