### PR TITLE
`clean` prunes stale tracking branches

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
@@ -51,9 +51,18 @@ class CliGitClient(
         }
     }
 
-    override fun fetch(remoteName: String) {
-        logger.trace("fetch {}", remoteName)
-        executeCommand(listOf("git", "fetch", remoteName))
+    override fun fetch(remoteName: String, prune: Boolean) {
+        logger.trace("fetch {}{}", remoteName, if (prune) " (with prune)" else "")
+        executeCommand(
+            buildList {
+                add("git")
+                add("fetch")
+                if (prune) {
+                    add("--prune")
+                }
+                add(remoteName)
+            },
+        )
     }
 
     override fun log(): List<Commit> {

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
@@ -9,7 +9,7 @@ interface GitClient {
     fun init(): GitClient
     fun checkout(refName: String): GitClient
     fun clone(uri: String, remoteName: String = DEFAULT_REMOTE_NAME, bare: Boolean = false): GitClient
-    fun fetch(remoteName: String)
+    fun fetch(remoteName: String, prune: Boolean = false)
     fun log(): List<Commit>
     fun log(revision: String, maxCount: Int = -1): List<Commit>
     fun logAll(): List<Commit>

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
@@ -61,10 +61,10 @@ class JGitClient(
         }
     }
 
-    override fun fetch(remoteName: String) {
-        logger.trace("fetch {}", remoteName)
+    override fun fetch(remoteName: String, prune: Boolean) {
+        logger.trace("fetch {}{}", remoteName, if (prune) " (with prune)" else "")
         try {
-            useGit { git -> git.fetch().setRemote(remoteName).call() }
+            useGit { git -> git.fetch().setRemote(remoteName).setRemoveDeletedRefs(prune).call() }
         } catch (e: TransportException) {
             throw GitJasprException("Failed to fetch from $remoteName; consider enabling the CLI git client", e)
         }

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/OptimizedCliGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/OptimizedCliGitClient.kt
@@ -15,8 +15,8 @@ class OptimizedCliGitClient private constructor(
         return this
     }
 
-    override fun fetch(remoteName: String) {
-        cliGitClient.fetch(remoteName)
+    override fun fetch(remoteName: String, prune: Boolean) {
+        cliGitClient.fetch(remoteName, prune)
     }
 
     override fun push(refSpecs: List<RefSpec>, remoteName: String) {


### PR DESCRIPTION
<!-- jaspr start -->
### `clean` prunes stale tracking branches

In the scenario where someone merges from another working copy, it's
possible for `git branch -r` to return a list containing branches that
no longer exist in the remote. This is mostly harmless, but it causes
`git jaspr clean` to include them in its output as orphaned branches,
which can be confusing. This change prunes the given remote before
getting the list of branches to avoid this scenario.

**Stack**:
- #211
- #210
- #209
- #208 ⬅
- #207
- #205
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia419d0c1_01..jaspr/main/Ia419d0c1)
- #204
- #203
- #202
- #201
- #200
- #199
- #198

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
