### PR TITLE
Log the GitJaspr version for all commands at DEBUG level

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -323,6 +323,7 @@ you'll need to re-enable it again.
         val (loggingContext, logFile) = initLogging(config.logLevel, config.logsDirectory)
         runBlocking {
             val logger = Cli.logger
+            logger.debug("{} version {}", GitJaspr::class.java.simpleName, VERSION)
             try {
                 doRun()
             } catch (e: GitJasprException) {
@@ -434,7 +435,7 @@ object Cli {
         is handled via an abstract base class.
          */
         NoOpCliktCommand(name = "git jaspr")
-            .versionOption("v17-beta")
+            .versionOption(VERSION)
             .subcommands(
                 listOf(
                     Status(),
@@ -450,6 +451,7 @@ object Cli {
     }
 }
 
+const val VERSION = "v17-beta"
 const val WORKING_DIR_PROPERTY_NAME = "git-jaspr-working-dir"
 const val CONFIG_FILE_NAME = ".git-jaspr.properties"
 const val DEFAULT_LOCAL_OBJECT = GitClient.HEAD


### PR DESCRIPTION
<!-- jaspr start -->
### Log the GitJaspr version for all commands at DEBUG level

**Stack**:
- #211
- #210
- #209 ⬅
- #208
- #207
- #205
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia419d0c1_01..jaspr/main/Ia419d0c1)
- #204
- #203
- #202
- #201
- #200
- #199
- #198

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
