### PR TITLE
Log file path is logged to console when using DEBUG or lower

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -346,11 +346,6 @@ you'll need to re-enable it again.
         val rootLogger = loggerContext.getLogger(Logger.ROOT_LOGGER_NAME)
         val fileAppender = if (logFileDirectory != null) createFileAppender(loggerContext, logFileDirectory) else null
 
-        if (fileAppender != null) {
-            rootLogger.addAppender(fileAppender)
-            Cli.logger.debug("Logging to {}", fileAppender.file)
-        }
-
         rootLogger.getAppender("STDOUT").apply {
             clearAllFilters()
             addFilter(
@@ -359,6 +354,11 @@ you'll need to re-enable it again.
                     start()
                 },
             )
+        }
+
+        if (fileAppender != null) {
+            rootLogger.addAppender(fileAppender)
+            Cli.logger.debug("Logging to {}", fileAppender.file)
         }
 
         return loggerContext to fileAppender?.file

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalExternalProcessTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprFunctionalExternalProcessTest.kt
@@ -49,7 +49,7 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
             strings = listOf("push", remoteName),
             invokeLocation = localRepo,
             javaOptions = javaOptions,
-        ).lines().drop(1).joinToString("\n") // Hacky, drop the first line which is debug output.
+        )
     }
 
     override suspend fun GitHubTestHarness.getAndPrintStatusString(refSpec: RefSpec): String {
@@ -63,8 +63,7 @@ class GitJasprFunctionalExternalProcessTest : GitJasprTest {
             strings = listOf("status", remoteName, refSpec.toString()),
             invokeLocation = localRepo,
             javaOptions = javaOptions,
-
-        ).lines().drop(1).joinToString("\n") // Hacky, drop the first line which is debug output.
+        )
     }
 
     override suspend fun GitHubTestHarness.merge(refSpec: RefSpec) {


### PR DESCRIPTION
<!-- jaspr start -->
### Log file path is logged to console when using DEBUG or lower

The initialization order here was a bit turned around. We were logging
the log file path (at DEBUG level), but doing so before fully
configuring logging from the CLI options. Since the bootstrap logging
level was INFO for the console appender, this meant the log file path
was being logged only to the actual log file itself... which isn't so
useful if you don't know where it is to begin with. :)

Now I apply all the log file options first, then log the path. This
means if you invoke the command with `-lDEBUG` (f.e.), you'll see the
path.

This also has the side effect of fixing a hack I was using for the
external process test... the log line containing the log file path was
being picked up as part of the output since the log configuration for
the test source set defaults to TRACE level, and this log configuration
is what's getting baked in when running the external process. Updating
the init order here means the default threshold filter of INFO level is
active, which suppresses the log file path line from the output of the
external process. Happy accident.

**Stack**:
- #211
- #210 ⬅
- #209
- #208
- #207
- #205
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia419d0c1_01..jaspr/main/Ia419d0c1)
- #204
- #203
- #202
- #201
- #200
- #199
- #198

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
