### PR TITLE
Bump styfle/cancel-workflow-action from 0.12.0 to 0.12.1

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@01ce38bf961b4e243a6342cbade0dbc8ba3f0432  # v0.12.0
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa  # v0.12.1
         with:
           access_token: ${{ github.token }}
 


### PR DESCRIPTION
<!-- jaspr start -->
### Bump styfle/cancel-workflow-action from 0.12.0 to 0.12.1

Bumps [styfle/cancel-workflow-action](https://github.com/styfle/cancel-workflow-action) from 0.12.0 to 0.12.1.
- [Release notes](https://github.com/styfle/cancel-workflow-action/releases)
- [Commits](https://github.com/styfle/cancel-workflow-action/compare/01ce38bf961b4e243a6342cbade0dbc8ba3f0432...85880fa0301c86cca9da44039ee3bb12d3bedbfa)

commit-id: Id54969cf

---
updated-dependencies:
- dependency-name: styfle/cancel-workflow-action
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

**Stack**:
- #235
- #234
- #233
- #232
- #231 ⬅
- #230

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
