### PR TITLE
Bump eregon/publish-release from 1.0.5 to 1.0.6

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -62,7 +62,7 @@ jobs:
     needs: ['create_release', 'native_builds']
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: eregon/publish-release@v1.0.5
+      - uses: eregon/publish-release@v1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
<!-- jaspr start -->
### Bump eregon/publish-release from 1.0.5 to 1.0.6

Bumps [eregon/publish-release](https://github.com/eregon/publish-release) from 1.0.5 to 1.0.6.
- [Release notes](https://github.com/eregon/publish-release/releases)
- [Commits](https://github.com/eregon/publish-release/compare/v1.0.5...v1.0.6)

commit-id: Ib249b651

---
updated-dependencies:
- dependency-name: eregon/publish-release
  dependency-type: direct:production
  update-type: version-update:semver-patch
...

Signed-off-by: dependabot[bot] <support@github.com>

**Stack**:
- #null
- #null
- #null
- #null ⬅
- #null
- #230

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
