### PR TITLE
Bump EnricoMi/publish-unit-test-result-action from 2.12.0 to 2.16.1

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@e780361cd1fc1b1a170624547b3ffda64787d365  # v2.12.0
+        uses: EnricoMi/publish-unit-test-result-action@30eadd5010312f995f0d3b3cff7fe2984f69409e  # v2.16.1
         if: always()
         with:
           junit_files: "**/build/test-results/**/*.xml"


### PR DESCRIPTION
<!-- jaspr start -->
### Bump EnricoMi/publish-unit-test-result-action from 2.12.0 to 2.16.1

Bumps [EnricoMi/publish-unit-test-result-action](https://github.com/enricomi/publish-unit-test-result-action) from 2.12.0 to 2.16.1.
- [Release notes](https://github.com/enricomi/publish-unit-test-result-action/releases)
- [Commits](https://github.com/enricomi/publish-unit-test-result-action/compare/e780361cd1fc1b1a170624547b3ffda64787d365...30eadd5010312f995f0d3b3cff7fe2984f69409e)

commit-id: I4e358370

---
updated-dependencies:
- dependency-name: EnricoMi/publish-unit-test-result-action
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

**Stack**:
- #235
- #234 ⬅
- #233
- #232
- #231
- #230

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
