### PR TITLE
Bump gradle/gradle-build-action from 2.11.1 to 3.3.1

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: 'Create Release'
         id: create_release
-        uses: "softprops/action-gh-release@v1"
+        uses: "softprops/action-gh-release@v2"
         with:
           draft: true
           generate_release_notes: true

--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -62,7 +62,7 @@ jobs:
     needs: ['create_release', 'native_builds']
     runs-on: 'ubuntu-latest'
     steps:
-      - uses: eregon/publish-release@v1.0.5
+      - uses: eregon/publish-release@v1.0.6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Cancel Previous Runs
-        uses: styfle/cancel-workflow-action@01ce38bf961b4e243a6342cbade0dbc8ba3f0432  # v0.12.0
+        uses: styfle/cancel-workflow-action@85880fa0301c86cca9da44039ee3bb12d3bedbfa  # v0.12.1
         with:
           access_token: ${{ github.token }}
 

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@e780361cd1fc1b1a170624547b3ffda64787d365  # v2.12.0
+        uses: EnricoMi/publish-unit-test-result-action@30eadd5010312f995f0d3b3cff7fe2984f69409e  # v2.16.1
         if: always()
         with:
           junit_files: "**/build/test-results/**/*.xml"

--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -63,7 +63,7 @@ jobs:
           java-version: "11.0.21-zulu"
 
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@982da8e78c05368c70dac0351bb82647a9e9a5d2 # v2.11.1
+        uses: gradle/gradle-build-action@e2097ccd7e8ed48671dc068ac4efa86d25745b39 # v3.3.1
 
       - name: Run Tests
         run: ./gradlew build --configure-on-demand --max-workers=4

--- a/git-jaspr/build.gradle.kts
+++ b/git-jaspr/build.gradle.kts
@@ -31,7 +31,7 @@ graalvmNative {
 
 graphql {
     client {
-        sdlEndpoint = "https://docs.github.com/public/schema.docs.graphql"
+        sdlEndpoint = "https://docs.github.com/public/fpt/schema.docs.graphql"
         queryFileDirectory = "src/graphql"
         packageName = "sims.michael.gitjaspr.generated"
         serializer = GraphQLSerializer.KOTLINX


### PR DESCRIPTION
<!-- jaspr start -->
### Bump gradle/gradle-build-action from 2.11.1 to 3.3.1

Bumps [gradle/gradle-build-action](https://github.com/gradle/gradle-build-action) from 2.11.1 to 3.3.1.
- [Release notes](https://github.com/gradle/gradle-build-action/releases)
- [Commits](https://github.com/gradle/gradle-build-action/compare/982da8e78c05368c70dac0351bb82647a9e9a5d2...e2097ccd7e8ed48671dc068ac4efa86d25745b39)

commit-id: I8f52d06a

---
updated-dependencies:
- dependency-name: gradle/gradle-build-action
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>

**Stack**:
- #235 ⬅
- #234
- #233
- #232
- #231
- #230

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
