### PR TITLE
Build and release uses Mac OS v14 (11 is gone)

### DIFF
--- a/.github/workflows/build_and_release.yml
+++ b/.github/workflows/build_and_release.yml
@@ -29,7 +29,7 @@ jobs:
         include:
           - os: 'ubuntu-20.04'
             label: 'linux'
-          - os: 'macos-11'
+          - os: 'macos-14-large'
             label: 'mac'
     runs-on: ${{matrix.os}}
     steps:


### PR DESCRIPTION
<!-- jaspr start -->
### Build and release uses Mac OS v14 (11 is gone)

**Stack**:
- #238
- #237 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
