### PR TITLE
`git jaspr status` shows commits in newest-first order

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -128,9 +128,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[ㄧㄧㄧㄧㄧㄧ] %s : one
-                    |[ㄧㄧㄧㄧㄧㄧ] %s : two
                     |[ㄧㄧㄧㄧㄧㄧ] %s : three
+                    |[ㄧㄧㄧㄧㄧㄧ] %s : two
+                    |[ㄧㄧㄧㄧㄧㄧ] %s : one
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -161,9 +161,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅ㄧㄧㄧㄧㄧ] %s : one
-                    |[ㄧㄧㄧㄧㄧㄧ] %s : two
                     |[ㄧㄧㄧㄧㄧㄧ] %s : three
+                    |[ㄧㄧㄧㄧㄧㄧ] %s : two
+                    |[✅ㄧㄧㄧㄧㄧ] %s : one
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -199,9 +199,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅⌛✅ㄧㄧ] %s : %s : one
-                    |[ㄧㄧㄧㄧㄧㄧ] %s : two
                     |[ㄧㄧㄧㄧㄧㄧ] %s : three
+                    |[ㄧㄧㄧㄧㄧㄧ] %s : two
+                    |[✅✅⌛✅ㄧㄧ] %s : %s : one
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -240,9 +240,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅ㄧㄧ] %s : %s : one
-                    |[ㄧㄧㄧㄧㄧㄧ] %s : two
                     |[ㄧㄧㄧㄧㄧㄧ] %s : three
+                    |[ㄧㄧㄧㄧㄧㄧ] %s : two
+                    |[✅✅✅✅ㄧㄧ] %s : %s : one
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -298,9 +298,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅✅✅] %s : %s : one
-                    |[✅✅✅✅ㄧㄧ] %s : %s : two
                     |[✅✅✅✅ㄧㄧ] %s : %s : three
+                    |[✅✅✅✅ㄧㄧ] %s : %s : two
+                    |[✅✅✅✅✅✅] %s : %s : one
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -367,9 +367,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅✅ㄧ] %s : %s : one
-                    |[✅✅✅✅✅ㄧ] %s : %s : two
                     |[✅✅✅✅✅ㄧ] %s : %s : three
+                    |[✅✅✅✅✅ㄧ] %s : %s : two
+                    |[✅✅✅✅✅ㄧ] %s : %s : one
                     |
                     |Your stack is out-of-date with the base branch (1 commit behind main).
                     |You'll need to rebase it (`git rebase $remoteName/main`) before your stack will be mergeable.
@@ -442,9 +442,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅✅ㄧ] %s : %s : one
-                    |[✅✅✅✅✅ㄧ] %s : %s : two
                     |[✅✅✅✅✅ㄧ] %s : %s : three
+                    |[✅✅✅✅✅ㄧ] %s : %s : two
+                    |[✅✅✅✅✅ㄧ] %s : %s : one
                     |
                     |Your stack is out-of-date with the base branch (2 commits behind main).
                     |You'll need to rebase it (`git rebase $remoteName/main`) before your stack will be mergeable.
@@ -505,9 +505,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅✅✅] %s : %s : one
-                    |[✅✅✅✅✅✅] %s : %s : two
                     |[✅✅✅✅✅✅] %s : %s : three
+                    |[✅✅✅✅✅✅] %s : %s : two
+                    |[✅✅✅✅✅✅] %s : %s : one
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -568,9 +568,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅✅✅] %s : %s : one
-                    |[✅✅✅✅✅✅] %s : %s : two
                     |[✅✅✅ㄧ✅ㄧ] %s : %s : draft: three
+                    |[✅✅✅✅✅✅] %s : %s : two
+                    |[✅✅✅✅✅✅] %s : %s : one
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -628,9 +628,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEventuallyEquals(
                 """
-                    |[✅✅✅✅ㄧㄧ] %s : %s : one
-                    |[✅✅✅✅✅ㄧ] %s : %s : two
                     |[✅✅✅✅ㄧㄧ] %s : %s : three
+                    |[✅✅✅✅✅ㄧ] %s : %s : two
+                    |[✅✅✅✅ㄧㄧ] %s : %s : one
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -687,9 +687,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[✅✅✅✅ㄧㄧ] %s : %s : one
-                    |[✅✅❌✅ㄧㄧ] %s : %s : two
                     |[✅✅✅✅ㄧㄧ] %s : %s : three
+                    |[✅✅❌✅ㄧㄧ] %s : %s : two
+                    |[✅✅✅✅ㄧㄧ] %s : %s : one
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -823,9 +823,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString(RefSpec("development", "main"))
             assertEquals(
                 """
-                    |[✅✅✅✅✅✅] %s : %s : one
-                    |[❗✅✅✅✅ㄧ] %s : %s : three
                     |[❗✅✅✅✅ㄧ] %s : %s : four
+                    |[❗✅✅✅✅ㄧ] %s : %s : three
+                    |[✅✅✅✅✅✅] %s : %s : one
                 """
                     .trimMargin()
                     .toStatusString(actual),
@@ -860,9 +860,9 @@ interface GitJasprTest {
             val actual = getAndPrintStatusString()
             assertEquals(
                 """
-                    |[❗ㄧㄧㄧㄧㄧ] %s : one
-                    |[❗ㄧㄧㄧㄧㄧ] %s : two
                     |[ㄧㄧㄧㄧㄧㄧ] %s : three
+                    |[❗ㄧㄧㄧㄧㄧ] %s : two
+                    |[❗ㄧㄧㄧㄧㄧ] %s : one
                     |
                     |Some commits in your local stack have duplicate IDs:
                     |- a: (one, two)


### PR DESCRIPTION
<!-- jaspr start -->
### `git jaspr status` shows commits in newest-first order

User feedback indicated it was preferable for the status output to use
the same order as the PR descriptions (and `git log`).

**Stack**:
- #253
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ica2cdf9d_01..jaspr/main/Ica2cdf9d)
- #252
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic2fe11af_02..jaspr/main/Ic2fe11af), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic2fe11af_01..jaspr/main/Ic2fe11af_02)
- #251
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If98182bd_02..jaspr/main/If98182bd), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If98182bd_01..jaspr/main/If98182bd_02)
- #250
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I05063698_01..jaspr/main/I05063698)
- #249 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I99b7be3c_01..jaspr/main/I99b7be3c)
- #248
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/a4f7c907_01..jaspr/main/a4f7c907)
- #247
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/607ae488_01..jaspr/main/607ae488)

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
