### PR TITLE
GitHub auth failures aren't treated as app failures

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/AppWiring.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/AppWiring.kt
@@ -61,7 +61,14 @@ class GitHubClientWiring(
     }
 
     val graphQLClient: GraphQLClient<*> by lazy {
-        GitHubGraphQLClient(GraphQLKtorClient(URL("https://api.github.com/graphql"), httpClient))
+        ErrorMappingGraphQLClient(
+            GitHubGraphQLClient(
+                GraphQLKtorClient(
+                    URL("https://api.github.com/graphql"),
+                    httpClient,
+                ),
+            ),
+        )
     }
 
     val gitHubClient: GitHubClient by lazy {

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/ErrorMappingGraphQLClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/ErrorMappingGraphQLClient.kt
@@ -1,0 +1,37 @@
+package sims.michael.gitjaspr
+
+import com.expediagroup.graphql.client.GraphQLClient
+import com.expediagroup.graphql.client.types.GraphQLClientRequest
+import com.expediagroup.graphql.client.types.GraphQLClientResponse
+import io.ktor.client.plugins.ClientRequestException
+import io.ktor.http.HttpStatusCode
+
+class ErrorMappingGraphQLClient<RequestCustomizer>(
+    private val delegate: GraphQLClient<RequestCustomizer>,
+) : GraphQLClient<RequestCustomizer> {
+    override suspend fun <T : Any> execute(
+        request: GraphQLClientRequest<T>,
+        requestCustomizer: RequestCustomizer.() -> Unit,
+    ): GraphQLClientResponse<T> = try {
+        delegate.execute(request, requestCustomizer)
+    } catch (e: ClientRequestException) {
+        mapException(e)
+    }
+
+    override suspend fun execute(
+        requests: List<GraphQLClientRequest<*>>,
+        requestCustomizer: RequestCustomizer.() -> Unit,
+    ): List<GraphQLClientResponse<*>> = try {
+        delegate.execute(requests, requestCustomizer)
+    } catch (e: ClientRequestException) {
+        mapException(e)
+    }
+
+    private fun mapException(e: ClientRequestException): Nothing {
+        if (e.response.status == HttpStatusCode.Unauthorized) {
+            throw GitJasprException("GitHub authorization failed, please check your token", e)
+        } else {
+            throw e
+        }
+    }
+}


### PR DESCRIPTION
<!-- jaspr start -->
### GitHub auth failures aren't treated as app failures

**Stack**:
- #253
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ica2cdf9d_01..jaspr/main/Ica2cdf9d)
- #252
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic2fe11af_02..jaspr/main/Ic2fe11af), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic2fe11af_01..jaspr/main/Ic2fe11af_02)
- #251
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If98182bd_02..jaspr/main/If98182bd), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If98182bd_01..jaspr/main/If98182bd_02)
- #250 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I05063698_01..jaspr/main/I05063698)
- #249
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I99b7be3c_01..jaspr/main/I99b7be3c)
- #248
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/a4f7c907_01..jaspr/main/a4f7c907)
- #247
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/607ae488_01..jaspr/main/607ae488)

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
