### PR TITLE
A dirty working directory isn't treated as an application error

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -89,8 +89,10 @@ class GitJaspr(
     suspend fun push(refSpec: RefSpec = RefSpec(DEFAULT_LOCAL_OBJECT, DEFAULT_TARGET_REF)) {
         logger.trace("push {}", refSpec)
 
-        check(gitClient.isWorkingDirectoryClean()) {
-            "Your working directory has local changes. Please commit or stash them and re-run the command."
+        if (!gitClient.isWorkingDirectoryClean()) {
+            throw GitJasprException(
+                "Your working directory has local changes. Please commit or stash them and re-run the command.",
+            )
         }
 
         val remoteName = config.remoteName

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/GitJasprTest.kt
@@ -59,7 +59,7 @@ interface GitJasprTest {
                     localWillBeDirty = true
                 },
             )
-            val exception = assertThrows<IllegalStateException> {
+            val exception = assertThrows<GitJasprException> {
                 push()
             }
             logger.info("Exception message is {}", exception.message)


### PR DESCRIPTION
<!-- jaspr start -->
### A dirty working directory isn't treated as an application error

**Stack**:
- #253
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ica2cdf9d_01..jaspr/main/Ica2cdf9d)
- #252
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic2fe11af_02..jaspr/main/Ic2fe11af), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic2fe11af_01..jaspr/main/Ic2fe11af_02)
- #251 ⬅
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If98182bd_02..jaspr/main/If98182bd), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If98182bd_01..jaspr/main/If98182bd_02)
- #250
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I05063698_01..jaspr/main/I05063698)
- #249
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I99b7be3c_01..jaspr/main/I99b7be3c)
- #248
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/a4f7c907_01..jaspr/main/a4f7c907)
- #247
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/607ae488_01..jaspr/main/607ae488)

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
