### PR TITLE
Improve output when branch cleanup requires retrying

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitJaspr.kt
@@ -526,6 +526,10 @@ class GitJaspr(
         while (true) {
             try {
                 gitClient.push(branchesToDelete, config.remoteName)
+                tries++
+                if (tries > 1) {
+                    logger.info("Successfully deleted branches after {} tries.", tries)
+                }
                 break
             } catch (e: Exception) {
                 tries++


### PR DESCRIPTION
<!-- jaspr start -->
### Improve output when branch cleanup requires retrying

If we get a transient error during branch cleanup and have to retry,
it's easy to assume the whole operation failed since the last thing you
see if the stack trace from the previous failed attempt. To mitigate
this somewhat, we print a success message after branch cleanup only if
it required 1 or more retries.

**Stack**:
- #253
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ica2cdf9d_01..jaspr/main/Ica2cdf9d)
- #252 ⬅
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic2fe11af_02..jaspr/main/Ic2fe11af), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic2fe11af_01..jaspr/main/Ic2fe11af_02)
- #251
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If98182bd_02..jaspr/main/If98182bd), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If98182bd_01..jaspr/main/If98182bd_02)
- #250
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I05063698_01..jaspr/main/I05063698)
- #249
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I99b7be3c_01..jaspr/main/I99b7be3c)
- #248
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/a4f7c907_01..jaspr/main/a4f7c907)
- #247
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/607ae488_01..jaspr/main/607ae488)

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
