### PR TITLE
Hotfix for "A pull request already exists" error

### DIFF
--- a/git-jaspr/src/graphql/getPullRequests.graphql
+++ b/git-jaspr/src/graphql/getPullRequests.graphql
@@ -12,7 +12,8 @@ query getPullRequests(
     }
     repository(owner:$repo_owner, name:$repo_name) {
         id
-        pullRequests(first:60, states:[OPEN]) {
+        # TODO - We should use pagination to get all PRs, rather than hardcoding a limit of 120
+        pullRequests(first:120, states:[OPEN]) {
             nodes {
                 id
                 number


### PR DESCRIPTION
<!-- jaspr start -->
### Hotfix for "A pull request already exists" error

The getPullRequests.graphql query contains a hardcoded limit on how many
PRs to fetch. It was set to 60 for some reason, and when using with a
repo that contains more than that number, it's possible for a PR in your
stack to not be in the response and therefore make Jaspr think it needs
to push a new one.

The proper fix for this is to paginate the PRs, but for now I'm bumping
up the limit to 120. I will revisit and fix properly soon.

**Stack**:
- #256
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ibd3dfde1_01..jaspr/main/Ibd3dfde1)
- #255 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia115de4b_01..jaspr/main/Ia115de4b)
- #257

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
