### PR TITLE
Bump EnricoMi/publish-unit-test-result-action from 2.17.1 to 2.18.0

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -70,7 +70,7 @@ jobs:
         shell: bash
 
       - name: Publish Unit Test Results
-        uses: EnricoMi/publish-unit-test-result-action@82082dac68ad6a19d980f8ce817e108b9f496c2a  # v2.17.1
+        uses: EnricoMi/publish-unit-test-result-action@170bf24d20d201b842d7a52403b73ed297e6645b  # v2.18.0
         if: always()
         with:
           junit_files: "**/build/test-results/**/*.xml"


### PR DESCRIPTION
<!-- jaspr start -->
### Bump EnricoMi/publish-unit-test-result-action from 2.17.1 to 2.18.0

Bumps [EnricoMi/publish-unit-test-result-action](https://github.com/enricomi/publish-unit-test-result-action) from 2.17.1 to 2.18.0.
- [Release notes](https://github.com/enricomi/publish-unit-test-result-action/releases)
- [Commits](https://github.com/enricomi/publish-unit-test-result-action/compare/82082dac68ad6a19d980f8ce817e108b9f496c2a...170bf24d20d201b842d7a52403b73ed297e6645b)

commit-id: I2176ecc6

---
updated-dependencies:
- dependency-name: EnricoMi/publish-unit-test-result-action
  dependency-type: direct:production
  update-type: version-update:semver-minor
...

Signed-off-by: dependabot[bot] <support@github.com>

**Stack**:
- #256
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ibd3dfde1_01..jaspr/main/Ibd3dfde1)
- #255
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia115de4b_01..jaspr/main/Ia115de4b)
- #257 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
