### PR TITLE
ErrorMappingGraphQLClient throws if the response contains any errors

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/ErrorMappingGraphQLClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/ErrorMappingGraphQLClient.kt
@@ -1,6 +1,7 @@
 package sims.michael.gitjaspr
 
 import com.expediagroup.graphql.client.GraphQLClient
+import com.expediagroup.graphql.client.types.GraphQLClientError
 import com.expediagroup.graphql.client.types.GraphQLClientRequest
 import com.expediagroup.graphql.client.types.GraphQLClientResponse
 import io.ktor.client.plugins.ClientRequestException
@@ -13,25 +14,34 @@ class ErrorMappingGraphQLClient<RequestCustomizer>(
         request: GraphQLClientRequest<T>,
         requestCustomizer: RequestCustomizer.() -> Unit,
     ): GraphQLClientResponse<T> = try {
-        delegate.execute(request, requestCustomizer)
+        delegate.execute(request, requestCustomizer).also(::failIfAnyErrors)
     } catch (e: ClientRequestException) {
-        mapException(e)
+        mapClientRequestException(e)
     }
 
     override suspend fun execute(
         requests: List<GraphQLClientRequest<*>>,
         requestCustomizer: RequestCustomizer.() -> Unit,
     ): List<GraphQLClientResponse<*>> = try {
-        delegate.execute(requests, requestCustomizer)
+        delegate.execute(requests, requestCustomizer).onEach(::failIfAnyErrors)
     } catch (e: ClientRequestException) {
-        mapException(e)
+        mapClientRequestException(e)
     }
 
-    private fun mapException(e: ClientRequestException): Nothing {
+    private fun mapClientRequestException(e: ClientRequestException): Nothing {
         if (e.response.status == HttpStatusCode.Unauthorized) {
             throw GitJasprException("GitHub authorization failed, please check your token", e)
         } else {
             throw e
+        }
+    }
+
+    private fun failIfAnyErrors(response: GraphQLClientResponse<*>) {
+        val errors = response.errors.orEmpty()
+        if (errors.isNotEmpty()) {
+            throw GitJasprException(
+                "GraphQL request failed with errors: ${errors.map(GraphQLClientError::message)}",
+            )
         }
     }
 }


### PR DESCRIPTION
<!-- jaspr start -->
### ErrorMappingGraphQLClient throws if the response contains any errors

**Stack**:
- #261
- #260
- #259 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
