### PR TITLE
Run junit tests in parallel to speed up verification

### DIFF
--- a/git-jaspr/src/test/resources/junit-platform.properties
+++ b/git-jaspr/src/test/resources/junit-platform.properties
@@ -1,0 +1,2 @@
+junit.jupiter.execution.parallel.enabled=true
+junit.jupiter.execution.parallel.mode.default=concurrent


### PR DESCRIPTION
<!-- jaspr start -->
### Run junit tests in parallel to speed up verification

Enabling this reduced execution time from 2m55s to 54s on my Mac Studio

**Stack**:
- #285
- #284
- #278
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_03..jaspr/main/If0762099), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_02..jaspr/main/If0762099_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_01..jaspr/main/If0762099_02)
- #275
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_03..jaspr/main/Ib9083f72), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_02..jaspr/main/Ib9083f72_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_01..jaspr/main/Ib9083f72_02)
- #274
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_03..jaspr/main/Iec232cfc), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_02..jaspr/main/Iec232cfc_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_01..jaspr/main/Iec232cfc_02)
- #273
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_03..jaspr/main/Ifaba9d1c), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_02..jaspr/main/Ifaba9d1c_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_01..jaspr/main/Ifaba9d1c_02)
- #269
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic3962919_02..jaspr/main/Ic3962919), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic3962919_01..jaspr/main/Ic3962919_02)
- #283
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I6e329078_01..jaspr/main/I6e329078)
- #282
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I73e7bac2_01..jaspr/main/I73e7bac2)
- #281
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I57638d30_01..jaspr/main/I57638d30)
- #280
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic597a1f1_01..jaspr/main/Ic597a1f1)
- #277
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia63d0e6a_02..jaspr/main/Ia63d0e6a), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia63d0e6a_01..jaspr/main/Ia63d0e6a_02)
- #276
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I29fd8488_02..jaspr/main/I29fd8488), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I29fd8488_01..jaspr/main/I29fd8488_02)
- #272
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I981f3062_02..jaspr/main/I981f3062), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I981f3062_01..jaspr/main/I981f3062_02)
- #271
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I09598d17_01..jaspr/main/I09598d17)
- #270
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iac28afbc_01..jaspr/main/Iac28afbc)
- #265
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I718c1b09_01..jaspr/main/I718c1b09)
- #264 ⬅

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
