### PR TITLE
Add --remote-named-stack-branch-prefix option + new validations

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Cli.kt
@@ -28,6 +28,7 @@ import org.intellij.lang.annotations.Language
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import sims.michael.gitjaspr.RemoteRefEncoding.DEFAULT_REMOTE_BRANCH_PREFIX
+import sims.michael.gitjaspr.RemoteRefEncoding.DEFAULT_REMOTE_NAMED_STACK_BRANCH_PREFIX
 import java.io.File
 
 //region Commands
@@ -269,7 +270,30 @@ you'll need to re-enable it again.
 
     private val remoteBranchPrefix by option()
         .default(DEFAULT_REMOTE_BRANCH_PREFIX)
-        .help { "The prefix to use for all git jaspr created branches in the remote" }
+        .help {
+            "The prefix to use when encoding unique commit IDs into remote ref names " +
+                "(example: $DEFAULT_REMOTE_BRANCH_PREFIX)"
+        }
+        .validate { value ->
+            if (value.contains("/")) {
+                fail("The remote branch prefix should not contain a forward slash; one will be appended automatically")
+            }
+        }
+
+    private val remoteNamedStackBranchPrefix by option()
+        .default(DEFAULT_REMOTE_NAMED_STACK_BRANCH_PREFIX)
+        .help { "The prefix to use when pushing named stacks (example: $DEFAULT_REMOTE_NAMED_STACK_BRANCH_PREFIX)" }
+        .validate { value ->
+            if (value.contains("/")) {
+                fail(
+                    "The remote named stack branch prefix should not contain a forward slash; one will be appended " +
+                        "automatically",
+                )
+            }
+            if (value == remoteBranchPrefix) {
+                fail("The remote named stack branch prefix should not be the same as the remote branch prefix")
+            }
+        }
 
     private val showConfig by option(hidden = true).flag("--no-show-config", default = false)
         .help { "Print the effective configuration to standard output (for debugging)" }
@@ -291,6 +315,7 @@ you'll need to re-enable it again.
             remoteName,
             githubInfo,
             remoteBranchPrefix,
+            remoteNamedStackBranchPrefix,
             logLevel,
             logsDirectory.takeIf { logToFiles },
         )

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Model.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/Model.kt
@@ -3,6 +3,7 @@ package sims.michael.gitjaspr
 import ch.qos.logback.classic.Level
 import kotlinx.serialization.Serializable
 import sims.michael.gitjaspr.RemoteRefEncoding.DEFAULT_REMOTE_BRANCH_PREFIX
+import sims.michael.gitjaspr.RemoteRefEncoding.DEFAULT_REMOTE_NAMED_STACK_BRANCH_PREFIX
 import sims.michael.gitjaspr.serde.FileSerializer
 import sims.michael.gitjaspr.serde.LevelSerializer
 import java.io.File
@@ -21,6 +22,7 @@ data class Config(
     val remoteName: String,
     val gitHubInfo: GitHubInfo,
     val remoteBranchPrefix: String = DEFAULT_REMOTE_BRANCH_PREFIX,
+    val remoteNamedStackBranchPrefix: String = DEFAULT_REMOTE_NAMED_STACK_BRANCH_PREFIX,
     @Serializable(with = LevelSerializer::class)
     val logLevel: Level = Level.INFO,
     @Serializable(with = FileSerializer::class)

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/RemoteRefEncoding.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/RemoteRefEncoding.kt
@@ -2,6 +2,7 @@ package sims.michael.gitjaspr
 
 object RemoteRefEncoding {
     const val DEFAULT_REMOTE_BRANCH_PREFIX = "jaspr"
+    const val DEFAULT_REMOTE_NAMED_STACK_BRANCH_PREFIX = "jaspr-named"
 
     const val REV_NUM_DELIMITER = "_"
 

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliTest.kt
@@ -226,6 +226,74 @@ class CliTest {
         assertTrue(scratchDir.repoDir().resolve(".git").resolve("hooks").resolve("commit-msg").canExecute())
     }
 
+    @Test
+    fun `fails if remoteBranchPrefix contains a forward slash`() {
+        val scratchDir = createTempDir()
+        val thrownMessage = assertThrows<IllegalStateException> {
+            executeCli(
+                scratchDir,
+                "git@github.com:SomeOwner/some-repo-name.git",
+                DEFAULT_REMOTE_NAME,
+                strings = listOf(
+                    "no-op",
+                    "--remote-branch-prefix",
+                    "jaspr/",
+                ),
+            )
+        }.message
+        assertNotNull(thrownMessage)
+        assertContains(
+            thrownMessage,
+            "The remote branch prefix should not contain a forward slash",
+        )
+    }
+
+    @Test
+    fun `fails if remoteNamedStackBranchPrefix contains a forward slash`() {
+        val scratchDir = createTempDir()
+        val thrownMessage = assertThrows<IllegalStateException> {
+            executeCli(
+                scratchDir,
+                "git@github.com:SomeOwner/some-repo-name.git",
+                DEFAULT_REMOTE_NAME,
+                strings = listOf(
+                    "no-op",
+                    "--remote-named-stack-branch-prefix",
+                    "jaspr-named/",
+                ),
+            )
+        }.message
+        assertNotNull(thrownMessage)
+        assertContains(
+            thrownMessage,
+            "The remote named stack branch prefix should not contain a forward slash",
+        )
+    }
+
+    @Test
+    fun `fails if remoteBranchPrefix and remoteNamedStackBranchPrefix are the same`() {
+        val scratchDir = createTempDir()
+        val thrownMessage = assertThrows<IllegalStateException> {
+            executeCli(
+                scratchDir,
+                "git@github.com:SomeOwner/some-repo-name.git",
+                DEFAULT_REMOTE_NAME,
+                strings = listOf(
+                    "no-op",
+                    "--remote-branch-prefix",
+                    "joe",
+                    "--remote-named-stack-branch-prefix",
+                    "joe",
+                ),
+            )
+        }.message
+        assertNotNull(thrownMessage)
+        assertContains(
+            thrownMessage,
+            "The remote named stack branch prefix should not be the same as the remote branch prefix",
+        )
+    }
+
     private fun config(workingDirectory: File, gitHubInfo: GitHubInfo, logsDirectory: File) = Config(
         workingDirectory,
         remoteName = DEFAULT_REMOTE_NAME,


### PR DESCRIPTION
<!-- jaspr start -->
### Add --remote-named-stack-branch-prefix option + new validations

This will be used in a subsequent commit.

**Stack**:
- #285
- #284
- #278
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_03..jaspr/main/If0762099), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_02..jaspr/main/If0762099_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_01..jaspr/main/If0762099_02)
- #275
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_03..jaspr/main/Ib9083f72), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_02..jaspr/main/Ib9083f72_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_01..jaspr/main/Ib9083f72_02)
- #274
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_03..jaspr/main/Iec232cfc), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_02..jaspr/main/Iec232cfc_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_01..jaspr/main/Iec232cfc_02)
- #273 ⬅
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_03..jaspr/main/Ifaba9d1c), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_02..jaspr/main/Ifaba9d1c_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_01..jaspr/main/Ifaba9d1c_02)
- #269
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic3962919_02..jaspr/main/Ic3962919), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic3962919_01..jaspr/main/Ic3962919_02)
- #283
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I6e329078_01..jaspr/main/I6e329078)
- #282
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I73e7bac2_01..jaspr/main/I73e7bac2)
- #281
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I57638d30_01..jaspr/main/I57638d30)
- #280
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic597a1f1_01..jaspr/main/Ic597a1f1)
- #277
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia63d0e6a_02..jaspr/main/Ia63d0e6a), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia63d0e6a_01..jaspr/main/Ia63d0e6a_02)
- #276
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I29fd8488_02..jaspr/main/I29fd8488), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I29fd8488_01..jaspr/main/I29fd8488_02)
- #272
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I981f3062_02..jaspr/main/I981f3062), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I981f3062_01..jaspr/main/I981f3062_02)
- #271
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I09598d17_01..jaspr/main/I09598d17)
- #270
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iac28afbc_01..jaspr/main/Iac28afbc)
- #265
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I718c1b09_01..jaspr/main/I718c1b09)
- #264

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
