### PR TITLE
Implement GitClient.isHeadDetached

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CliGitClient.kt
@@ -335,6 +335,11 @@ class CliGitClient(
             .trim()
     }
 
+    override fun isHeadDetached(): Boolean {
+        logger.trace("isHeadDetached")
+        return getCurrentBranchName().isEmpty()
+    }
+
     private fun gitLog(vararg logArg: String): List<Commit> {
         // Thanks to https://www.nushell.sh/cookbook/parsing_git_log.html for inspiration here
         val prettyFormat = listOf(

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/GitClient.kt
@@ -34,6 +34,7 @@ interface GitClient {
     fun setUpstreamBranch(remoteName: String, branchName: String)
     fun reflog(): List<Commit>
     fun getCurrentBranchName(): String
+    fun isHeadDetached(): Boolean
 
     companion object {
         const val HEAD = Constants.HEAD

--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/JGitClient.kt
@@ -333,6 +333,13 @@ class JGitClient(
         return useGit { git -> git.repository.branch }
     }
 
+    override fun isHeadDetached(): Boolean {
+        logger.trace("isHeadDetached")
+        return useGit { git ->
+            !git.repository.exactRef(Constants.HEAD).isSymbolic
+        }
+    }
+
     private inline fun <T> useGit(block: (Git) -> T): T = Git.open(workingDirectory).use(block)
 
     companion object {

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliGitClientTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CliGitClientTest.kt
@@ -532,6 +532,23 @@ class CliGitClientTest {
     }
 
     @Test
+    fun `compare isHeadDetached`() {
+        withTestSetup {
+            val cliGit = CliGitClient(localGit.workingDirectory)
+            val git = JGitClient(localGit.workingDirectory)
+            assertEquals(
+                cliGit.isHeadDetached(),
+                git.isHeadDetached(),
+            )
+            cliGit.checkout(cliGit.log().first().hash)
+            assertEquals(
+                cliGit.isHeadDetached(),
+                git.isHeadDetached(),
+            )
+        }
+    }
+
+    @Test
     fun testInit() {
         withTestSetup {
             val git = CliGitClient(localGit.workingDirectory.resolve("new-repo"))
@@ -840,6 +857,16 @@ This is a commit body
         withTestSetup {
             val git = CliGitClient(localGit.workingDirectory)
             assertEquals("main", git.getCurrentBranchName())
+        }
+    }
+
+    @Test
+    fun testIsHeadDetached() {
+        withTestSetup {
+            val git = CliGitClient(localGit.workingDirectory)
+            assertFalse(git.isHeadDetached())
+            git.checkout(git.log().first().hash)
+            assertTrue(git.isHeadDetached())
         }
     }
 }


### PR DESCRIPTION
<!-- jaspr start -->
### Implement GitClient.isHeadDetached

**Stack**:
- #285
- #284
- #278
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_03..jaspr/main/If0762099), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_02..jaspr/main/If0762099_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_01..jaspr/main/If0762099_02)
- #275
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_03..jaspr/main/Ib9083f72), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_02..jaspr/main/Ib9083f72_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_01..jaspr/main/Ib9083f72_02)
- #274
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_03..jaspr/main/Iec232cfc), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_02..jaspr/main/Iec232cfc_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_01..jaspr/main/Iec232cfc_02)
- #273
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_03..jaspr/main/Ifaba9d1c), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_02..jaspr/main/Ifaba9d1c_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_01..jaspr/main/Ifaba9d1c_02)
- #269
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic3962919_02..jaspr/main/Ic3962919), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic3962919_01..jaspr/main/Ic3962919_02)
- #283
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I6e329078_01..jaspr/main/I6e329078)
- #282
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I73e7bac2_01..jaspr/main/I73e7bac2)
- #281
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I57638d30_01..jaspr/main/I57638d30)
- #280
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic597a1f1_01..jaspr/main/Ic597a1f1)
- #277 ⬅
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia63d0e6a_02..jaspr/main/Ia63d0e6a), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia63d0e6a_01..jaspr/main/Ia63d0e6a_02)
- #276
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I29fd8488_02..jaspr/main/I29fd8488), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I29fd8488_01..jaspr/main/I29fd8488_02)
- #272
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I981f3062_02..jaspr/main/I981f3062), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I981f3062_01..jaspr/main/I981f3062_02)
- #271
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I09598d17_01..jaspr/main/I09598d17)
- #270
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iac28afbc_01..jaspr/main/Iac28afbc)
- #265
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I718c1b09_01..jaspr/main/I718c1b09)
- #264

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
