### PR TITLE
GitHubTestHarness: properly handle creating "sibling" branches

### DIFF
--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/githubtests/GitHubTestHarness.kt
@@ -194,8 +194,8 @@ class GitHubTestHarness private constructor(
                 if (commitData.branches.isNotEmpty()) {
                     for (childBranch in commitData.branches) {
                         childBranch.createCommits()
+                        localGit.checkout(commit.hash)
                     }
-                    localGit.checkout(commit.hash)
                 }
             }
         }


### PR DESCRIPTION
<!-- jaspr start -->
### GitHubTestHarness: properly handle creating "sibling" branches

The test harness was not properly creating a repo structure with
"sibling" branches like B, C, and D in this example:

* a9b9cdf - 2
| * 5d41f9d - (C) 1.2
|/
| * c5a2e1c - (D) 1.3
|/
| * 7b83731 - (B) 1.1
|/
* e162c52 - 1
* 8543836 - (main) Initial commit

It was creating B, C, and D as children in the same branch. After
recursing into a branch, createCommits() needed to do a checkout
to reset the repo state before creating the next one.

**Stack**:
- #285
- #284
- #278
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_03..jaspr/main/If0762099), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_02..jaspr/main/If0762099_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/If0762099_01..jaspr/main/If0762099_02)
- #275
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_03..jaspr/main/Ib9083f72), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_02..jaspr/main/Ib9083f72_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ib9083f72_01..jaspr/main/Ib9083f72_02)
- #274
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_03..jaspr/main/Iec232cfc), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_02..jaspr/main/Iec232cfc_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec232cfc_01..jaspr/main/Iec232cfc_02)
- #273
  - [03..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_03..jaspr/main/Ifaba9d1c), [02..03](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_02..jaspr/main/Ifaba9d1c_03), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ifaba9d1c_01..jaspr/main/Ifaba9d1c_02)
- #269
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic3962919_02..jaspr/main/Ic3962919), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic3962919_01..jaspr/main/Ic3962919_02)
- #283
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I6e329078_01..jaspr/main/I6e329078)
- #282
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I73e7bac2_01..jaspr/main/I73e7bac2)
- #281 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I57638d30_01..jaspr/main/I57638d30)
- #280
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ic597a1f1_01..jaspr/main/Ic597a1f1)
- #277
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia63d0e6a_02..jaspr/main/Ia63d0e6a), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Ia63d0e6a_01..jaspr/main/Ia63d0e6a_02)
- #276
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I29fd8488_02..jaspr/main/I29fd8488), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I29fd8488_01..jaspr/main/I29fd8488_02)
- #272
  - [02..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I981f3062_02..jaspr/main/I981f3062), [01..02](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I981f3062_01..jaspr/main/I981f3062_02)
- #271
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I09598d17_01..jaspr/main/I09598d17)
- #270
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iac28afbc_01..jaspr/main/Iac28afbc)
- #265
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/I718c1b09_01..jaspr/main/I718c1b09)
- #264

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
