### PR TITLE
Footers with spaces in their values are parsed correctly

### DIFF
--- a/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CommitParsers.kt
+++ b/git-jaspr/src/main/kotlin/sims/michael/gitjaspr/CommitParsers.kt
@@ -59,7 +59,7 @@ object CommitParsers {
         val maybeFooterSection = fullMessageTrimmed.substringAfterLast("\n\n")
         if (maybeFooterSection == fullMessageTrimmed) return emptyMap() // Just a subject
 
-        val footerLineRegex = "^([^\\s:]+): ([^\\s:]+)$".toRegex()
+        val footerLineRegex = "^([^\\s:]+): ([^:]+)$".toRegex()
 
         val maybeFooterLines = maybeFooterSection.lines()
         return if (maybeFooterLines.all { line -> footerLineRegex.matches(line) }) {

--- a/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CommitParsersTest.kt
+++ b/git-jaspr/src/test/kotlin/sims/michael/gitjaspr/CommitParsersTest.kt
@@ -151,6 +151,35 @@ class CommitParsersTest {
     }
 
     @Test
+    fun `getFooters - footer value with spaces`() {
+        val message = """
+This is a commit subject
+
+Co-authored-by: John Carmack <jcarmack@idsoftware.com>
+commit-id: I0e9e0b26
+        """.trimIndent()
+
+        assertEquals(
+            mapOf("Co-authored-by" to "John Carmack <jcarmack@idsoftware.com>", "commit-id" to "I0e9e0b26"),
+            getFooters(message),
+        )
+    }
+
+    @Test
+    fun `getFooters - footer key with spaces`() {
+        val message = """
+This is a commit subject
+
+keys with spaces are not allowed: value
+        """.trimIndent()
+
+        assertEquals(
+            emptyMap(),
+            getFooters(message),
+        )
+    }
+
+    @Test
     fun `addFooters - subject only`() {
         assertEquals(
             """


### PR DESCRIPTION
<!-- jaspr start -->
### Footers with spaces in their values are parsed correctly

**Stack**:
- #289
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iec2871f1_01..jaspr/main/Iec2871f1)
- #288 ⬅
  - [01..Current](https://github.com/MichaelSims/git-jaspr/compare/jaspr/main/Iefa59c71_01..jaspr/main/Iefa59c71)

⚠️ *Part of a stack created by [jaspr](https://github.com/MichaelSims/git-jaspr). Do not merge manually using the UI - doing so may have unexpected results.*
